### PR TITLE
feat(marker)!: calculate distance distribution from samples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,21 +3,6 @@
 version = 4
 
 [[package]]
-name = "aho-corasick"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "anes"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
-
-[[package]]
 name = "anstyle"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -57,55 +42,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
-name = "bumpalo"
-version = "3.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
-
-[[package]]
 name = "bytemuck"
 version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6b1fc10dbac614ebc03540c9dbd60e83887fda27794998c6528f1782047d540"
 
 [[package]]
-name = "cast"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
-
-[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "ciborium"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
-dependencies = [
- "ciborium-io",
- "ciborium-ll",
- "serde",
-]
-
-[[package]]
-name = "ciborium-io"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
-
-[[package]]
-name = "ciborium-ll"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
-dependencies = [
- "ciborium-io",
- "half",
-]
 
 [[package]]
 name = "clap"
@@ -124,6 +70,7 @@ checksum = "83b0f35019843db2160b5bb19ae09b4e6411ac33fc6a712003c33e03090e2489"
 dependencies = [
  "anstyle",
  "clap_lex",
+ "terminal_size",
 ]
 
 [[package]]
@@ -133,40 +80,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
-name = "criterion"
-version = "0.5.1"
+name = "condtype"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
-dependencies = [
- "anes",
- "cast",
- "ciborium",
- "clap",
- "criterion-plot",
- "is-terminal",
- "itertools",
- "num-traits",
- "once_cell",
- "oorandom",
- "plotters",
- "rayon",
- "regex",
- "serde",
- "serde_derive",
- "serde_json",
- "tinytemplate",
- "walkdir",
-]
-
-[[package]]
-name = "criterion-plot"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
-dependencies = [
- "cast",
- "itertools",
-]
+checksum = "baf0a07a401f374238ab8e2f11a104d2851bf9ce711ec69804834de8af45c7af"
 
 [[package]]
 name = "crossbeam-deque"
@@ -194,10 +111,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
-name = "crunchy"
-version = "0.2.3"
+name = "divan"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
+checksum = "e0583193020b29b03682d8d33bb53a5b0f50df6daacece12ca99b904cfdcb8c4"
+dependencies = [
+ "cfg-if",
+ "clap",
+ "condtype",
+ "divan-macros",
+ "libc",
+ "regex-lite",
+]
+
+[[package]]
+name = "divan-macros"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8dc51d98e636f5e3b0759a39257458b22619cac7e96d932da6eeb052891bb67c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "either"
@@ -206,11 +142,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "errno"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "evo-marker"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "bitcode",
- "criterion",
+ "divan",
  "frequency",
  "rand",
  "rayon",
@@ -220,8 +166,10 @@ dependencies = [
 name = "frequency"
 version = "0.1.0"
 dependencies = [
- "criterion",
+ "bytemuck",
+ "divan",
  "nohash-hasher",
+ "num-traits",
  "rand",
  "rayon",
 ]
@@ -239,74 +187,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "half"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7db2ff139bba50379da6aa0766b52fdcb62cb5b263009b09ed58ba604e14bbd1"
-dependencies = [
- "cfg-if",
- "crunchy",
-]
-
-[[package]]
-name = "hermit-abi"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbd780fe5cc30f81464441920d82ac8740e2e46b29a6fad543ddd075229ce37e"
-
-[[package]]
-name = "is-terminal"
-version = "0.4.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys",
-]
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itoa"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
-
-[[package]]
-name = "js-sys"
-version = "0.3.77"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
-dependencies = [
- "once_cell",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "libc"
 version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
-name = "log"
-version = "0.4.27"
+name = "linux-raw-sys"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
-
-[[package]]
-name = "memchr"
-version = "2.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
 
 [[package]]
 name = "nohash-hasher"
@@ -321,46 +211,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "once_cell"
-version = "1.21.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2806eaa3524762875e21c3dcd057bc4b7bfa01ce4da8d46be1cd43649e1cc6b"
-
-[[package]]
-name = "oorandom"
-version = "11.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
-
-[[package]]
-name = "plotters"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
-dependencies = [
- "num-traits",
- "plotters-backend",
- "plotters-svg",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "plotters-backend"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
-
-[[package]]
-name = "plotters-svg"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
-dependencies = [
- "plotters-backend",
 ]
 
 [[package]]
@@ -447,85 +297,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "1.11.1"
+name = "regex-lite"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
+
+[[package]]
+name = "rustix"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e56a18552996ac8d29ecc3b190b4fdbb2d91ca4ec396de7bbffaf43f3d637e96"
 dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
-
-[[package]]
-name = "rustversion"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
-
-[[package]]
-name = "ryu"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
-
-[[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
-name = "serde"
-version = "1.0.219"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
-dependencies = [
- "serde_derive",
-]
-
-[[package]]
-name = "serde_derive"
-version = "1.0.219"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "serde_json"
-version = "1.0.140"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
-dependencies = [
- "itoa",
- "memchr",
- "ryu",
- "serde",
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
 ]
 
 [[package]]
@@ -540,13 +327,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinytemplate"
-version = "1.2.1"
+name = "terminal_size"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+checksum = "45c6481c4829e4cc63825e62c49186a34538b7b2750b73b266581ffb612fb5ed"
 dependencies = [
- "serde",
- "serde_json",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]
@@ -556,99 +343,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
-name = "walkdir"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
-dependencies = [
- "same-file",
- "winapi-util",
-]
-
-[[package]]
 name = "wasi"
 version = "0.14.2+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
 dependencies = [
  "wit-bindgen-rt",
-]
-
-[[package]]
-name = "wasm-bindgen"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
-dependencies = [
- "cfg-if",
- "once_cell",
- "rustversion",
- "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
-dependencies = [
- "quote",
- "wasm-bindgen-macro-support",
-]
-
-[[package]]
-name = "wasm-bindgen-macro-support"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-backend",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-shared"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
-dependencies = [
- "unicode-ident",
-]
-
-[[package]]
-name = "web-sys"
-version = "0.3.77"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "winapi-util"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
-dependencies = [
- "windows-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,10 @@ edition = "2024"
 frequency = { path = "crates/frequency" }
 
 bitcode = { version = "0", features = ["derive"], default-features = false }
-criterion = "0.5.1"
+bytemuck = "1.22.0"
+divan = "0.1.17"
+nohash-hasher = "0.2.0"
+num-traits = "0.2.19"
 rand = { version = "0.9.0", default-features = false, features = ["std"] }
 rayon = { version = "1.10.0" }
 

--- a/crates/frequency/Cargo.toml
+++ b/crates/frequency/Cargo.toml
@@ -13,8 +13,10 @@ parallel = ["dep:rayon"]
 rayon = { workspace = true, optional = true }
 
 [dev-dependencies]
-criterion = { workspace = true }
-nohash-hasher = "0.2.0"
+bytemuck = { workspace = true }
+divan = { workspace = true }
+nohash-hasher = { workspace = true }
+num-traits = { workspace = true }
 rand = { workspace = true, features = ["os_rng", "small_rng"] }
 
 [[bench]]

--- a/crates/frequency/README.md
+++ b/crates/frequency/README.md
@@ -1,4 +1,4 @@
-# frequency
+# Frequency
 
 A crate for counting occurrences (frequency) of unique elements in iterators.
 
@@ -36,15 +36,15 @@ assert_eq!(frequencies["banana"], 2);
 assert_eq!(frequencies["orange"], 1);
 ```
 
-## Frequency Trait
+## Frequency type
 
-The crate provides two main traits for frequency calculation:
+The crate provides two types of frequency calculation:
 
-### [`Frequency`]
+### Normal 
 
 Normal frequency calculation where items have the same weight.
 
-### [`WeightedFrequency`]
+### Weighted Frequency
 
 Calculates the frequency where items have different weights.
 

--- a/crates/frequency/benches/bounded_freq.rs
+++ b/crates/frequency/benches/bounded_freq.rs
@@ -1,133 +1,211 @@
 //! Benchmarking to compare different methods of calculating frequency for elements in a range
-//!
-//! ## Benchmark Results Summary (Apple M1)
-//!
-//! - BoundedIterator implementation: Approximately 2% slower than the manual implementation.
-//! - Unchecked variants: Approximately 10% faster than their checked counterparts.
-//! - BoundedParallelIterator performance characteristics:
-//!   - Small datasets (2^16 elements): Significantly slower than serial implementations
-//!   - Medium datasets (2^24 elements): Comparable performance to serial implementations
-//!   - Large datasets (2^30 elements): Faster than serial implementations
-//!
-//! The parallel implementation's performance is affected by:
-//!
-//! 1. Parallel execution overhead.
-//! 2. Cache sharing between threads, which may increase cache misses.
-//!
-//! Note: In real-world scenarios with "cold" data (not cached), parallel implementations
-//! may demonstrate better relative performance than shown in these benchmarks due to
-//! reduced impact of cache-related bottlenecks.
+
+/*
+Results on my machine (Apple M1, lto=fat, target-cpu=native):
+
+bounded_freq                      fastest       │ slowest       │ median        │ mean          │ samples │ iters
+╰─ compare_methods                              │               │               │               │         │
+   ├─ bounded_iter                              │               │               │               │         │
+   │  ├─ u16                                    │               │               │               │         │
+   │  │  ├─ 65536                 23.53 µs      │ 29.51 µs      │ 23.99 µs      │ 23.98 µs      │ 100     │ 1000
+   │  │  ├─ 1048576               370.8 µs      │ 431.3 µs      │ 374.4 µs      │ 378.1 µs      │ 100     │ 1000
+   │  │  ╰─ 16777216              5.945 ms      │ 7.714 ms      │ 6.066 ms      │ 6.075 ms      │ 100     │ 1000
+   │  ╰─ u32                                    │               │               │               │         │
+   │     ├─ 65536                 23.68 µs      │ 30.82 µs      │ 25.71 µs      │ 25.74 µs      │ 100     │ 1000
+   │     ├─ 1048576               374 µs        │ 648.4 µs      │ 382.5 µs      │ 390.7 µs      │ 100     │ 1000
+   │     ╰─ 16777216              6.018 ms      │ 9.644 ms      │ 6.11 ms       │ 6.141 ms      │ 100     │ 1000
+   ├─ bounded_iter_unchecked                    │               │               │               │         │
+   │  ├─ u16                                    │               │               │               │         │
+   │  │  ├─ 65536                 21.56 µs      │ 29.58 µs      │ 22.38 µs      │ 23.16 µs      │ 100     │ 1000
+   │  │  ├─ 1048576               339.7 µs      │ 373.5 µs      │ 350.5 µs      │ 350.3 µs      │ 100     │ 1000
+   │  │  ╰─ 16777216              5.536 ms      │ 12.63 ms      │ 5.588 ms      │ 5.774 ms      │ 100     │ 1000
+   │  ╰─ u32                                    │               │               │               │         │
+   │     ├─ 65536                 21.89 µs      │ 38.37 µs      │ 24.27 µs      │ 24.07 µs      │ 100     │ 1000
+   │     ├─ 1048576               343.8 µs      │ 384.5 µs      │ 354.2 µs      │ 356.5 µs      │ 100     │ 1000
+   │     ╰─ 16777216              5.584 ms      │ 6.081 ms      │ 5.646 ms      │ 5.652 ms      │ 100     │ 1000
+   ├─ bounded_par_iter                          │               │               │               │         │
+   │  ├─ u16                                    │               │               │               │         │
+   │  │  ├─ 65536                 1.084 ms      │ 3.363 ms      │ 1.905 ms      │ 1.975 ms      │ 100     │ 1000
+   │  │  ├─ 1048576               2.488 ms      │ 6.545 ms      │ 3.965 ms      │ 4.112 ms      │ 100     │ 1000
+   │  │  ╰─ 16777216              5.019 ms      │ 8.188 ms      │ 6.116 ms      │ 6.158 ms      │ 100     │ 1000
+   │  ╰─ u32                                    │               │               │               │         │
+   │     ├─ 65536                 1.501 ms      │ 5.362 ms      │ 3.392 ms      │ 3.449 ms      │ 100     │ 1000
+   │     ├─ 1048576               2.511 ms      │ 5.578 ms      │ 3.816 ms      │ 3.843 ms      │ 100     │ 1000
+   │     ╰─ 16777216              4.067 ms      │ 9.609 ms      │ 6.092 ms      │ 6.428 ms      │ 100     │ 1000
+   ├─ bounded_par_iter_unchecked                │               │               │               │         │
+   │  ├─ u16                                    │               │               │               │         │
+   │  │  ├─ 65536                 1.965 ms      │ 5.068 ms      │ 2.891 ms      │ 2.993 ms      │ 100     │ 1000
+   │  │  ├─ 1048576               2.48 ms       │ 7.702 ms      │ 3.723 ms      │ 3.871 ms      │ 100     │ 1000
+   │  │  ╰─ 16777216              4.83 ms       │ 7.904 ms      │ 5.67 ms       │ 5.776 ms      │ 100     │ 1000
+   │  ╰─ u32                                    │               │               │               │         │
+   │     ├─ 65536                 1.512 ms      │ 4.548 ms      │ 2.462 ms      │ 2.574 ms      │ 100     │ 1000
+   │     ├─ 1048576               2.283 ms      │ 7.259 ms      │ 3.104 ms      │ 3.233 ms      │ 100     │ 1000
+   │     ╰─ 16777216              4.726 ms      │ 7.604 ms      │ 5.779 ms      │ 5.84 ms       │ 100     │ 1000
+   ├─ hash_iter                                 │               │               │               │         │
+   │  ├─ u16                                    │               │               │               │         │
+   │  │  ├─ 65536                 294.7 µs      │ 456.1 µs      │ 303.6 µs      │ 309.4 µs      │ 100     │ 1000
+   │  │  ├─ 1048576               3.441 ms      │ 5.822 ms      │ 3.651 ms      │ 3.751 ms      │ 100     │ 1000
+   │  │  ╰─ 16777216              53.64 ms      │ 61.51 ms      │ 54.35 ms      │ 55.24 ms      │ 100     │ 1000
+   │  ╰─ u32                                    │               │               │               │         │
+   │     ├─ 65536                 296.3 µs      │ 761.6 µs      │ 307.2 µs      │ 321.7 µs      │ 100     │ 1000
+   │     ├─ 1048576               3.435 ms      │ 4.913 ms      │ 3.647 ms      │ 3.698 ms      │ 100     │ 1000
+   │     ╰─ 16777216              53.67 ms      │ 62.74 ms      │ 55.93 ms      │ 56.27 ms      │ 100     │ 1000
+   ├─ manual                                    │               │               │               │         │
+   │  ├─ u16                                    │               │               │               │         │
+   │  │  ├─ 65536                 24 µs         │ 34.92 µs      │ 26.77 µs      │ 27.08 µs      │ 100     │ 1000
+   │  │  ├─ 1048576               378.6 µs      │ 604.6 µs      │ 400 µs        │ 417.8 µs      │ 100     │ 1000
+   │  │  ╰─ 16777216              6.039 ms      │ 7.464 ms      │ 6.089 ms      │ 6.161 ms      │ 100     │ 1000
+   │  ╰─ u32                                    │               │               │               │         │
+   │     ├─ 65536                 24.14 µs      │ 31.54 µs      │ 25.82 µs      │ 25.66 µs      │ 100     │ 1000
+   │     ├─ 1048576               381.8 µs      │ 636.7 µs      │ 398 µs        │ 407.3 µs      │ 100     │ 1000
+   │     ╰─ 16777216              6.119 ms      │ 8.899 ms      │ 6.394 ms      │ 6.546 ms      │ 100     │ 1000
+   ╰─ manual_unchecked                          │               │               │               │         │
+      ├─ u16                                    │               │               │               │         │
+      │  ├─ 65536                 22.31 µs      │ 82.83 µs      │ 23.41 µs      │ 27.5 µs       │ 100     │ 1000
+      │  ├─ 1048576               349.8 µs      │ 945.8 µs      │ 369.8 µs      │ 401.9 µs      │ 100     │ 1000
+      │  ╰─ 16777216              5.572 ms      │ 9.203 ms      │ 5.702 ms      │ 5.817 ms      │ 100     │ 1000
+      ╰─ u32                                    │               │               │               │         │
+         ├─ 65536                 22.27 µs      │ 33.61 µs      │ 24.6 µs       │ 24.75 µs      │ 100     │ 1000
+         ├─ 1048576               352.3 µs      │ 397.6 µs      │ 359.6 µs      │ 363.3 µs      │ 100     │ 1000
+         ╰─ 16777216              5.639 ms      │ 8.409 ms      │ 5.779 ms      │ 5.908 ms      │ 100     │ 1000
+*/
 
 mod manual;
 
-use criterion::{Criterion, criterion_group, criterion_main};
+use std::{collections::HashMap, sync::LazyLock};
+
+use divan::Bencher;
 use frequency::prelude::*;
 use manual::*;
-use rand::{distr::Uniform, prelude::*, rngs::SmallRng};
+use rand::{
+    distr::{Uniform, uniform::SampleUniform},
+    prelude::*,
+    rngs::SmallRng,
+};
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 
-fn compare_bounded_freq<T, C>(c: &mut Criterion, size: usize, max_value: usize, data: &[T])
-where
-    T: ToUsize + Sync + Send + Copy,
-    C: Count + Send,
-{
-    let mut group = c.benchmark_group(format!(
-        "Compare Methods (T: {}, U: {}, Size: {}, Max Value: {})",
-        std::any::type_name::<T>(),
-        std::any::type_name::<C>(),
-        size,
-        max_value,
-    ));
+fn main() {
+    divan::main();
+}
 
-    group.bench_with_input("Manual", &(&data, max_value), |b, &(data, max_value)| {
-        b.iter(|| bounded_freq::<T, C>(data, max_value))
+const SIZES: &[usize] = &[1 << 16, 1 << 20, 1 << 24];
+
+fn prepare_data<T>(size: usize) -> (Vec<T>, usize)
+where
+    T: num_traits::PrimInt + SampleUniform + bytemuck::AnyBitPattern,
+{
+    const MAX_VALUE: usize = 4096;
+
+    fn cast_vec<A, B>(src: &[A]) -> Vec<B>
+    where
+        A: bytemuck::NoUninit,
+        B: bytemuck::AnyBitPattern,
+    {
+        bytemuck::cast_slice(src).to_vec()
+    }
+
+    fn gen_data<T>(size: usize) -> Vec<T>
+    where
+        T: num_traits::PrimInt + SampleUniform,
+    {
+        Uniform::new_inclusive(T::zero(), T::from(MAX_VALUE).unwrap_or(T::max_value()))
+            .unwrap()
+            .sample_iter(&mut SmallRng::seed_from_u64(42))
+            .take(size)
+            .collect()
+    }
+
+    // Use precomputed data to avoid generating data for each benchmark run
+    static BENCH_DATA: LazyLock<HashMap<(usize, &'static str), Vec<u8>>> = LazyLock::new(|| {
+        let mut data = HashMap::new();
+
+        for &size in SIZES {
+            // data.insert((size, "u8"), cast_vec(&gen_data::<u8>(size)));
+            data.insert((size, "u16"), cast_vec(&gen_data::<u16>(size)));
+            data.insert((size, "u32"), cast_vec(&gen_data::<u32>(size)));
+        }
+
+        data
     });
 
-    group.bench_with_input(
-        "Manual (Unchecked)",
-        &(&data, max_value),
-        |b, &(data, max_value)| {
-            b.iter(|| unsafe { unchecked_bounded_freq::<T, C>(data, max_value) })
-        },
-    );
-
-    group.bench_with_input(
-        "BoundedIterator",
-        &(&data, max_value),
-        |b, &(data, max_value)| {
-            b.iter(|| {
-                let freq: Vec<C> = data.iter().copied().into_bounded_iter(max_value).freq();
-                freq
-            })
-        },
-    );
-
-    group.bench_with_input(
-        "BoundedIterator (Unchecked)",
-        &(&data, max_value),
-        |b, &(data, max_value)| {
-            b.iter(|| {
-                let freq: Vec<C> = unsafe {
-                    data.iter()
-                        .copied()
-                        .into_unchecked_bounded_iter(max_value)
-                        .freq()
-                };
-                freq
-            })
-        },
-    );
-
-    #[cfg(feature = "parallel")]
-    group.bench_with_input(
-        "BoundedParallelIterator",
-        &(&data, max_value),
-        |b, &(&data, max_value)| {
-            b.iter(|| {
-                let freq: Vec<C> = data
-                    .par_iter()
-                    .copied()
-                    .into_bounded_par_iter(max_value)
-                    .freq();
-                freq
-            })
-        },
-    );
-
-    #[cfg(feature = "parallel")]
-    group.bench_with_input(
-        "BoundedParallelIterator (Unchecked)",
-        &(&data, max_value),
-        |b, &(&data, max_value)| {
-            b.iter(|| {
-                let freq: Vec<C> = unsafe {
-                    data.par_iter()
-                        .copied()
-                        .into_unchecked_bounded_par_iter(max_value)
-                        .freq()
-                };
-                freq
-            })
-        },
-    );
-
-    group.finish();
+    (
+        cast_vec(BENCH_DATA.get(&(size, std::any::type_name::<T>())).unwrap()),
+        MAX_VALUE,
+    )
 }
 
-fn bench_methods(c: &mut Criterion) {
-    let mut rng = SmallRng::seed_from_u64(42);
-    let max_value = 4096;
-    for size in [1 << 16, 1 << 24] {
-        let data: Vec<_> = Uniform::new(0, max_value as u16)
-            .unwrap()
-            .sample_iter(&mut rng)
-            .take(size)
-            .collect();
-        compare_bounded_freq::<_, usize>(c, size, max_value, &data);
+#[divan::bench_group(sample_count = 100, sample_size = 10)]
+mod compare_methods {
+
+    use super::*;
+
+    macro_rules! bench_bounded_freq {
+        ($name:ident, $func:expr) => {
+            #[divan::bench(args = SIZES, types = [u16, u32])]
+            fn $name<T>(bencher: Bencher, size: usize)
+            where
+                T: SampleUniform
+                    + ToUsize
+                    + Eq
+                    + std::hash::Hash
+                    + nohash_hasher::IsEnabled
+                    + num_traits::PrimInt
+                    + bytemuck::AnyBitPattern
+                    + Send
+                    + Sync,
+            {
+                bencher
+                    .with_inputs(|| prepare_data::<T>(size))
+                    .bench_local_refs($func)
+            }
+        };
     }
+
+    bench_bounded_freq!(manual, |(data, max_value)| bounded_freq::<T, usize>(
+        data, *max_value
+    ));
+    bench_bounded_freq!(manual_unchecked, |(data, max_value)| unsafe {
+        unchecked_bounded_freq::<T, usize>(data, *max_value)
+    });
+
+    bench_bounded_freq!(bounded_iter, |(data, max_value)| {
+        let freq: Vec<usize> = data.iter().copied().into_bounded_iter(*max_value).freq();
+        freq
+    });
+
+    bench_bounded_freq!(bounded_iter_unchecked, |(data, max_value)| unsafe {
+        let freq: Vec<usize> = data
+            .iter()
+            .copied()
+            .into_unchecked_bounded_iter(*max_value)
+            .freq();
+        freq
+    });
+
+    // 10x slower than other implementations, so commented out to decrease benchmarking time.
+    // bench_bounded_freq!(hash_iter, |(data, _)| {
+    //     let freq: nohash_hasher::IntMap<T, usize> = data.iter().copied().into_hash_iter().freq();
+    //     freq
+    // });
+
+    #[cfg(feature = "parallel")]
+    bench_bounded_freq!(bounded_par_iter, |(data, max_value)| {
+        let freq: Vec<usize> = data
+            .par_iter()
+            .copied()
+            .into_bounded_par_iter(*max_value)
+            .freq();
+        freq
+    });
+
+    #[cfg(feature = "parallel")]
+    bench_bounded_freq!(bounded_par_iter_unchecked, |(data, max_value)| unsafe {
+        let freq: Vec<usize> = data
+            .par_iter()
+            .copied()
+            .into_unchecked_bounded_par_iter(*max_value)
+            .freq();
+        freq
+    });
 }
-
-criterion_group!(benches, bench_methods);
-
-criterion_main!(benches);

--- a/crates/marker/Cargo.toml
+++ b/crates/marker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "evo-marker"
-version = "0.1.1"
+version = "0.2.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -16,7 +16,7 @@ rand = { workspace = true }
 rayon = { workspace = true }
 
 [dev-dependencies]
-criterion = { workspace = true }
+divan = { workspace = true }
 rand = { workspace = true, features = ["os_rng", "small_rng"] }
 
 [[bench]]

--- a/crates/marker/benches/ssa.rs
+++ b/crates/marker/benches/ssa.rs
@@ -1,4 +1,4 @@
-use criterion::black_box;
+use divan::black_box;
 use evo_marker::prelude::*;
 use rand::prelude::*;
 
@@ -6,7 +6,7 @@ fn max_size() -> usize {
     black_box(100000)
 }
 
-fn sample_size() -> usize {
+pub fn sample_size() -> usize {
     black_box(10000)
 }
 
@@ -62,10 +62,6 @@ pub fn birth_death_ssa<M: Marker>(b: f64, d: f64, max_n: usize, rng: &mut impl R
     }
 
     cells
-}
-
-pub fn down_sample(cells: Vec<LineageNode>, rng: &mut impl Rng) -> Vec<LineageNode> {
-    cells.choose_multiple(rng, sample_size()).cloned().collect()
 }
 
 /// Find the first n such that `(n + 1) * unit >= r`.

--- a/crates/marker/src/lineage/rmq/mod.rs
+++ b/crates/marker/src/lineage/rmq/mod.rs
@@ -78,7 +78,7 @@ impl<T: Copy + Ord, I: Copy> Ord for MinAndPos<T, I> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[cfg_attr(feature = "bitcode", derive(bitcode::Decode, bitcode::Encode))]
 pub struct BlockRMQ<const N: u32> {
     blocks: Vec<Block>,

--- a/crates/marker/src/lineage/rmq/sparse_table.rs
+++ b/crates/marker/src/lineage/rmq/sparse_table.rs
@@ -3,7 +3,7 @@
 use super::MinAndPos;
 
 /// Sparse table for RMQ
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[cfg_attr(feature = "bitcode", derive(bitcode::Decode, bitcode::Encode))]
 pub struct RmqSpareTable<T: Clone + Copy + Ord> {
     len: usize,


### PR DESCRIPTION
Now, the distance distribution can be calculated from a random subset of samples to reduce the computational cost.

And switch from Criterion to Divan for benchmarking.