### PR TITLE
feat(validate): add parameter validation crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,4 +101,5 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: codecov.json
+          use_pypi: true
           fail_ci_if_error: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1195,6 +1195,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "validate"
+version = "0.1.0"
+
+[[package]]
 name = "varint-rs"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ rayon = { version = "1.10.0" }
 serde = { version = "1", default-features = false }
 tempfile = { version = "3.20.0" }
 thiserror = { version = "2" }
+validate = { path = "crates/validate", version = "0.1" }
 zerocopy = { version = "0.8.26" }
 zstd = { version = "0.13", default-features = false }
 

--- a/crates/validate/Cargo.toml
+++ b/crates/validate/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "validate"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+
+[lints]
+workspace = true

--- a/crates/validate/README.md
+++ b/crates/validate/README.md
@@ -18,7 +18,7 @@ fn configure(rate: f64, probability: f64) -> Result<(), ValidationError> {
 Failures display the parameter name, the actual value formatted with `Debug`, and a short expected condition. The parameter name is also available through `ValidationError::name()`.
 
 ```rust
-use validate::{ValidationError, validate};
+use validate::validate;
 
 let steps = 0;
 let error = validate!(steps: >= 1).unwrap_err();
@@ -27,7 +27,6 @@ assert_eq!(
     error.to_string(),
     "invalid parameter `steps`: expected >= 1, got 0"
 );
-# let _: ValidationError = error;
 ```
 
 ## Supported Forms

--- a/crates/validate/README.md
+++ b/crates/validate/README.md
@@ -35,37 +35,40 @@ assert_eq!(
 Comparison checks put the validated identifier or field path before `:`. Field paths may use named or tuple fields. Bounds are full Rust expressions.
 
 ```rust
-# use validate::validate;
-# let rate = -0.1;
-let _ = validate!(rate: > 0.0);
-let _ = validate!(rate: >= 0.0);
-let _ = validate!(rate: < 1.0);
-let _ = validate!(rate: <= 1.0);
+# use validate::{ValidationError, validate};
+# let rate = 0.5;
+validate!(rate: > 0.0)?;
+validate!(rate: >= 0.0)?;
+validate!(rate: < 1.0)?;
+validate!(rate: <= 1.0)?;
 # struct Config { rate: f64 }
-# let config = Config { rate: -0.1 };
-let _ = validate!(config.rate: > 0.0);
-# let config = (0,);
-let _ = validate!(config.0: >= 1);
+# let config = Config { rate: 0.5 };
+validate!(config.rate: > 0.0)?;
+# let config = (1,);
+validate!(config.0: >= 1)?;
+# Ok::<(), ValidationError>(())
 ```
 
 Range checks use two comma-separated clauses and render the corresponding interval. Bounds are full Rust expressions.
 
 ```rust
-# use validate::validate;
-# let probability = 1.2;
+# use validate::{ValidationError, validate};
+# let probability = 0.5;
 # let min = 0.0;
 # let max = 1.0;
-let _ = validate!(probability: >= 0.0, <= 1.0);
-let _ = validate!(probability: > 0.0, < 1.0);
-let _ = validate!(probability: >= 0.0, < 1.0);
-let _ = validate!(probability: > 0.0, <= 1.0);
-let _ = validate!(probability: >= min, <= max);
+validate!(probability: >= 0.0, <= 1.0)?;
+validate!(probability: > 0.0, < 1.0)?;
+validate!(probability: >= 0.0, < 1.0)?;
+validate!(probability: > 0.0, <= 1.0)?;
+validate!(probability: >= min, <= max)?;
+# Ok::<(), ValidationError>(())
 ```
 
 Custom checks use `;` to separate an arbitrary boolean expression from its static expected description.
 
 ```rust
-# use validate::validate;
-# let sigma = f64::NAN;
-let _ = validate!(sigma: sigma.is_finite(); "finite");
+# use validate::{ValidationError, validate};
+# let sigma = 1.0_f64;
+validate!(sigma: sigma.is_finite(); "finite")?;
+# Ok::<(), ValidationError>(())
 ```

--- a/crates/validate/README.md
+++ b/crates/validate/README.md
@@ -1,0 +1,66 @@
+# Validate
+
+`validate` is a tiny crate for parameter validation in library code. It provides a diagnostic error type and a macro for common parameter checks.
+
+## Quick Start
+
+```rust
+use validate::{ParameterError, validate};
+
+fn configure(rate: f64, probability: f64) -> Result<(), ParameterError> {
+    validate!(rate > 0.0)?;
+    validate!(0.0 <= probability <= 1.0)?;
+    validate!(rate, rate.is_finite(), "finite")?;
+    Ok(())
+}
+```
+
+Failures display the parameter name, the actual value formatted with `Debug`, and a short expected condition. The parameter name is also available through `ParameterError::name()`.
+
+```rust
+use validate::{ParameterError, validate};
+
+let steps = 0;
+let error = validate!(steps >= 1).unwrap_err();
+assert_eq!(error.name(), "steps");
+assert_eq!(
+    error.to_string(),
+    "invalid parameter `steps`: expected >= 1, got 0"
+);
+# let _: ParameterError = error;
+```
+
+## Supported Forms
+
+Comparison checks infer the parameter name from an identifier or one field access.
+
+```rust
+# use validate::validate;
+# let rate = -0.1;
+let _ = validate!(rate > 0.0);
+let _ = validate!(rate >= 0.0);
+let _ = validate!(rate < 1.0);
+let _ = validate!(rate <= 1.0);
+```
+
+Range checks use mathematical notation and render the corresponding interval.
+
+```rust
+# use validate::validate;
+# let probability = 1.2;
+# let min = 0.0;
+# let max = 1.0;
+let _ = validate!(0.0 <= probability <= 1.0);
+let _ = validate!(0.0 < probability < 1.0);
+let _ = validate!(0.0 <= probability < 1.0);
+let _ = validate!(0.0 < probability <= 1.0);
+let _ = validate!((min) <= probability <= (max));
+```
+
+Custom checks accept the value to report, a boolean condition, and a static expected description.
+
+```rust
+# use validate::validate;
+# let sigma = f64::NAN;
+let _ = validate!(sigma, sigma.is_finite(), "finite");
+```

--- a/crates/validate/README.md
+++ b/crates/validate/README.md
@@ -5,9 +5,9 @@
 ## Quick Start
 
 ```rust
-use validate::{ParameterError, validate};
+use validate::{ValidationError, validate};
 
-fn configure(rate: f64, probability: f64) -> Result<(), ParameterError> {
+fn configure(rate: f64, probability: f64) -> Result<(), ValidationError> {
     validate!(rate > 0.0)?;
     validate!(0.0 <= probability <= 1.0)?;
     validate!(rate, rate.is_finite(), "finite")?;
@@ -15,10 +15,10 @@ fn configure(rate: f64, probability: f64) -> Result<(), ParameterError> {
 }
 ```
 
-Failures display the parameter name, the actual value formatted with `Debug`, and a short expected condition. The parameter name is also available through `ParameterError::name()`.
+Failures display the parameter name, the actual value formatted with `Debug`, and a short expected condition. The parameter name is also available through `ValidationError::name()`.
 
 ```rust
-use validate::{ParameterError, validate};
+use validate::{ValidationError, validate};
 
 let steps = 0;
 let error = validate!(steps >= 1).unwrap_err();
@@ -27,7 +27,7 @@ assert_eq!(
     error.to_string(),
     "invalid parameter `steps`: expected >= 1, got 0"
 );
-# let _: ParameterError = error;
+# let _: ValidationError = error;
 ```
 
 ## Supported Forms

--- a/crates/validate/README.md
+++ b/crates/validate/README.md
@@ -8,9 +8,9 @@
 use validate::{ValidationError, validate};
 
 fn configure(rate: f64, probability: f64) -> Result<(), ValidationError> {
-    validate!(rate > 0.0)?;
-    validate!(0.0 <= probability <= 1.0)?;
-    validate!(rate, rate.is_finite(), "finite")?;
+    validate!(rate: > 0.0)?;
+    validate!(probability: >= 0.0, <= 1.0)?;
+    validate!(rate: rate.is_finite(); "finite")?;
     Ok(())
 }
 ```
@@ -21,7 +21,7 @@ Failures display the parameter name, the actual value formatted with `Debug`, an
 use validate::{ValidationError, validate};
 
 let steps = 0;
-let error = validate!(steps >= 1).unwrap_err();
+let error = validate!(steps: >= 1).unwrap_err();
 assert_eq!(error.name(), "steps");
 assert_eq!(
     error.to_string(),
@@ -32,35 +32,40 @@ assert_eq!(
 
 ## Supported Forms
 
-Comparison checks infer the parameter name from an identifier or one field access.
+Comparison checks put the validated identifier or field path before `:`. Field paths may use named or tuple fields. Bounds are full Rust expressions.
 
 ```rust
 # use validate::validate;
 # let rate = -0.1;
-let _ = validate!(rate > 0.0);
-let _ = validate!(rate >= 0.0);
-let _ = validate!(rate < 1.0);
-let _ = validate!(rate <= 1.0);
+let _ = validate!(rate: > 0.0);
+let _ = validate!(rate: >= 0.0);
+let _ = validate!(rate: < 1.0);
+let _ = validate!(rate: <= 1.0);
+# struct Config { rate: f64 }
+# let config = Config { rate: -0.1 };
+let _ = validate!(config.rate: > 0.0);
+# let config = (0,);
+let _ = validate!(config.0: >= 1);
 ```
 
-Range checks use mathematical notation and render the corresponding interval.
+Range checks use two comma-separated clauses and render the corresponding interval. Bounds are full Rust expressions.
 
 ```rust
 # use validate::validate;
 # let probability = 1.2;
 # let min = 0.0;
 # let max = 1.0;
-let _ = validate!(0.0 <= probability <= 1.0);
-let _ = validate!(0.0 < probability < 1.0);
-let _ = validate!(0.0 <= probability < 1.0);
-let _ = validate!(0.0 < probability <= 1.0);
-let _ = validate!((min) <= probability <= (max));
+let _ = validate!(probability: >= 0.0, <= 1.0);
+let _ = validate!(probability: > 0.0, < 1.0);
+let _ = validate!(probability: >= 0.0, < 1.0);
+let _ = validate!(probability: > 0.0, <= 1.0);
+let _ = validate!(probability: >= min, <= max);
 ```
 
-Custom checks accept the value to report, a boolean condition, and a static expected description.
+Custom checks use `;` to separate an arbitrary boolean expression from its static expected description.
 
 ```rust
 # use validate::validate;
 # let sigma = f64::NAN;
-let _ = validate!(sigma, sigma.is_finite(), "finite");
+let _ = validate!(sigma: sigma.is_finite(); "finite");
 ```

--- a/crates/validate/src/lib.rs
+++ b/crates/validate/src/lib.rs
@@ -1,4 +1,5 @@
 #![doc = include_str!("../README.md")]
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 
 /// Error returned when a parameter fails validation.
 ///

--- a/crates/validate/src/lib.rs
+++ b/crates/validate/src/lib.rs
@@ -263,6 +263,19 @@ mod tests {
     }
 
     #[test]
+    fn comparison_accepts_expression_bounds() {
+        let min_count = 1;
+        let count = 1;
+        let error = validate!(count: > min_count + 1).unwrap_err();
+
+        assert_validation_error(
+            error,
+            "count",
+            "invalid parameter `count`: expected > min_count + 1, got 1",
+        );
+    }
+
+    #[test]
     fn inclusive_range_checks_identifier_parameters() {
         let probability = 1.2;
         let error = validate!(probability: >= 0.0, <= 1.0).unwrap_err();
@@ -321,6 +334,18 @@ mod tests {
     }
 
     #[test]
+    fn range_checks_tuple_field_paths() {
+        let config = (1.5,);
+        let error = validate!(config.0: >= 0.0, <= 1.0).unwrap_err();
+
+        assert_validation_error(
+            error,
+            "config.0",
+            "invalid parameter `config.0`: expected in [0.0, 1.0], got 1.5",
+        );
+    }
+
+    #[test]
     fn range_accepts_expression_bounds() {
         let lower = -2.0;
         let upper = 2.0;
@@ -335,6 +360,26 @@ mod tests {
     }
 
     #[test]
+    fn range_evaluates_expression_bounds_once() {
+        fn next(calls: &std::cell::Cell<usize>) -> f64 {
+            let current = calls.get();
+            calls.set(current + 1);
+            current as f64
+        }
+
+        let calls = std::cell::Cell::new(0);
+        let score = 2.0;
+        let error = validate!(score: > next(&calls), < next(&calls)).unwrap_err();
+
+        assert_eq!(calls.get(), 2);
+        assert_validation_error(
+            error,
+            "score",
+            "invalid parameter `score`: expected in (next(&calls), next(&calls)), got 2.0",
+        );
+    }
+
+    #[test]
     fn custom_checks_use_inferred_value_name() {
         let sigma = f64::NAN;
         let error = validate!(sigma: sigma.is_finite(); "finite").unwrap_err();
@@ -343,6 +388,29 @@ mod tests {
             error,
             "sigma",
             "invalid parameter `sigma`: expected finite, got NaN",
+        );
+    }
+
+    #[test]
+    fn custom_checks_report_field_path_value() {
+        struct Inner {
+            sigma: f64,
+        }
+
+        struct Config {
+            inner: Inner,
+        }
+
+        let config = Config {
+            inner: Inner { sigma: f64::NAN },
+        };
+        let error =
+            validate!(config.inner.sigma: config.inner.sigma.is_finite(); "finite").unwrap_err();
+
+        assert_validation_error(
+            error,
+            "config.inner.sigma",
+            "invalid parameter `config.inner.sigma`: expected finite, got NaN",
         );
     }
 }

--- a/crates/validate/src/lib.rs
+++ b/crates/validate/src/lib.rs
@@ -1,0 +1,394 @@
+#![doc = include_str!("../README.md")]
+
+/// Error returned when a parameter fails validation.
+///
+/// The full diagnostic is available through [`std::fmt::Display`]. Use [`ParameterError::name`]
+/// when you need the failing parameter name separately.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParameterError {
+    name: &'static str,
+    value: String,
+    expected: &'static str,
+}
+
+impl ParameterError {
+    /// Return the name of the parameter that failed validation.
+    pub const fn name(&self) -> &'static str {
+        self.name
+    }
+
+    #[doc(hidden)]
+    pub fn __new(name: &'static str, value: String, expected: &'static str) -> Self {
+        Self {
+            name,
+            value,
+            expected,
+        }
+    }
+}
+
+impl std::fmt::Display for ParameterError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "invalid parameter `{}`: expected {}, got {}",
+            self.name, self.expected, self.value
+        )
+    }
+}
+
+impl std::error::Error for ParameterError {}
+
+/// Validate a parameter and return [`ParameterError`] on failure.
+///
+/// # Examples
+///
+/// ```
+/// use validate::{ParameterError, validate};
+///
+/// fn configure(rate: f64, probability: f64) -> Result<(), ParameterError> {
+///     validate!(rate > 0.0)?;
+///     validate!(0.0 <= probability <= 1.0)?;
+///     validate!(rate, rate.is_finite(), "finite")?;
+///     Ok(())
+/// }
+/// ```
+#[macro_export]
+macro_rules! validate {
+    // Range with parenthesized expression bounds for a plain identifier:
+    // `validate!((min()) <= probability < (max()))`.
+    (($lower:expr) $lower_operator:tt $name:ident $upper_operator:tt ($upper:expr) $(,)?) => {
+        $crate::validate!(
+            @range (stringify!($name), $name),
+            $lower,
+            $lower_operator,
+            $upper_operator,
+            $upper
+        )
+    };
+    // Range with parenthesized expression bounds for one field access:
+    // `validate!((min()) <= config.probability < (max()))`.
+    (($lower:expr) $lower_operator:tt $receiver:tt.$field:ident $upper_operator:tt ($upper:expr) $(,)?) => {
+        $crate::validate!(
+            @range (stringify!($field), $receiver.$field),
+            $lower,
+            $lower_operator,
+            $upper_operator,
+            $upper
+        )
+    };
+    // Range with literal bounds for a plain identifier:
+    // `validate!(0.0 <= probability < 1.0)`.
+    ($lower:literal $lower_operator:tt $name:ident $upper_operator:tt $upper:literal $(,)?) => {
+        $crate::validate!(
+            @range (stringify!($name), $name),
+            $lower,
+            $lower_operator,
+            $upper_operator,
+            $upper
+        )
+    };
+    // Range with literal bounds for one field access:
+    // `validate!(0.0 <= config.probability < 1.0)`.
+    ($lower:literal $lower_operator:tt $receiver:tt.$field:ident $upper_operator:tt $upper:literal $(,)?) => {
+        $crate::validate!(
+            @range (stringify!($field), $receiver.$field),
+            $lower,
+            $lower_operator,
+            $upper_operator,
+            $upper
+        )
+    };
+    // Comparison for one field access:
+    // `validate!(config.steps >= 1)`.
+    ($receiver:tt.$field:ident $operator:tt $bound:expr $(,)?) => {
+        $crate::validate!(@cmp (stringify!($field), $receiver.$field), $operator, $bound)
+    };
+    // Comparison for a plain identifier:
+    // `validate!(steps >= 1)`.
+    ($name:ident $operator:tt $bound:expr $(,)?) => {
+        $crate::validate!(@cmp (stringify!($name), $name), $operator, $bound)
+    };
+    // Custom predicate with an explicit diagnostic name:
+    // `validate!("sigma", value, value.is_finite(), "finite")`.
+    ($name:literal, $value:expr, $condition:expr, $expected:expr $(,)?) => {{
+        $crate::validate!(@check $condition, $name, &$value, $expected)
+    }};
+    // Custom predicate that uses the value expression text as the diagnostic name:
+    // `validate!(sigma, sigma.is_finite(), "finite")`.
+    ($value:expr, $condition:expr, $expected:expr $(,)?) => {{
+        $crate::validate!(@check $condition, stringify!($value), &$value, $expected)
+    }};
+    // Shared comparison implementation. Public comparison arms only extract `(name, value)`;
+    // this arm evaluates the value and bound once, then delegates condition checking.
+    (@cmp ($name:expr, $value:expr), $operator:tt, $bound:expr) => {{
+        let value = &$value;
+        let bound = $bound;
+        $crate::validate!(
+            @check value $operator &bound,
+            $name,
+            value,
+            $crate::validate!(@cmp_expected $operator, $bound)
+        )
+    }};
+    // Shared range implementation. Lower and upper are evaluated once, and the operators decide
+    // whether each side is open or closed.
+    (@range (
+        $name:expr,
+        $value:expr
+    ), $lower:expr, $lower_operator:tt, $upper_operator:tt, $upper:expr) => {{
+        let value = &$value;
+        let lower = $lower;
+        let upper = $upper;
+        $crate::validate!(
+            @check &lower $lower_operator value && value $upper_operator &upper,
+            $name,
+            value,
+            $crate::validate!(@range_expected $lower_operator, $upper_operator, $lower, $upper)
+        )
+    }};
+    // Render the expected interval text for open and closed range combinations.
+    (@range_expected <, <, $lower:expr, $upper:expr) => {
+        concat!("in (", stringify!($lower), ", ", stringify!($upper), ")")
+    };
+    (@range_expected <, <=, $lower:expr, $upper:expr) => {
+        concat!("in (", stringify!($lower), ", ", stringify!($upper), "]")
+    };
+    (@range_expected <=, <, $lower:expr, $upper:expr) => {
+        concat!("in [", stringify!($lower), ", ", stringify!($upper), ")")
+    };
+    (@range_expected <=, <=, $lower:expr, $upper:expr) => {
+        concat!("in [", stringify!($lower), ", ", stringify!($upper), "]")
+    };
+    // Render the expected comparison text for the supported comparison operators.
+    (@cmp_expected >, $bound:expr) => {
+        concat!("> ", stringify!($bound))
+    };
+    (@cmp_expected >=, $bound:expr) => {
+        concat!(">= ", stringify!($bound))
+    };
+    (@cmp_expected <, $bound:expr) => {
+        concat!("< ", stringify!($bound))
+    };
+    (@cmp_expected <=, $bound:expr) => {
+        concat!("<= ", stringify!($bound))
+    };
+    // Convert a boolean validation result into `Result<(), ParameterError>`.
+    (@check $condition:expr, $name:expr, $value:expr, $expected:expr) => {{
+        if $condition {
+            ::core::result::Result::Ok(())
+        } else {
+            $crate::validate!(@invalid $name, $value, $expected)
+        }
+    }};
+    // Build the diagnostic error. The value is formatted only on the failure path.
+    (@invalid $name:expr, $value:expr, $expected:expr) => {
+        ::core::result::Result::Err($crate::ParameterError::__new(
+            $name,
+            ::std::format!("{:?}", $value),
+            $expected,
+        ))
+    };
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+
+    fn assert_parameter_error(error: ParameterError, name: &'static str, display: &str) {
+        assert_eq!(error.name(), name);
+        assert_eq!(error.to_string(), display);
+    }
+
+    #[test]
+    fn display_orders_expected_before_actual_value() {
+        let error = ParameterError::__new("rate", "-1.0".to_owned(), "> 0.0");
+
+        assert_eq!(
+            error.to_string(),
+            "invalid parameter `rate`: expected > 0.0, got -1.0"
+        );
+    }
+
+    #[test]
+    fn comparison_checks_identifier_parameters() {
+        let rate = -0.1;
+        let error = validate!(rate > 0.0).unwrap_err();
+
+        assert_parameter_error(
+            error,
+            "rate",
+            "invalid parameter `rate`: expected > 0.0, got -0.1",
+        );
+
+        let rate = 0.1;
+        assert!(validate!(rate > 0.0).is_ok());
+    }
+
+    #[test]
+    fn comparison_checks_field_parameters() {
+        struct Config {
+            steps: usize,
+        }
+
+        let config = Config { steps: 0 };
+        let error = validate!(config.steps >= 1).unwrap_err();
+
+        assert_parameter_error(
+            error,
+            "steps",
+            "invalid parameter `steps`: expected >= 1, got 0",
+        );
+    }
+
+    #[test]
+    fn comparison_checks_self_fields() {
+        struct Config {
+            rate: f64,
+        }
+
+        impl Config {
+            fn validate(&self) -> Result<(), ParameterError> {
+                validate!(self.rate > 0.0)
+            }
+        }
+
+        let error = Config { rate: 0.0 }.validate().unwrap_err();
+
+        assert_parameter_error(
+            error,
+            "rate",
+            "invalid parameter `rate`: expected > 0.0, got 0.0",
+        );
+    }
+
+    #[test]
+    fn comparison_checks_render_each_supported_operator() {
+        let count = 3;
+        assert_parameter_error(
+            validate!(count < 3).unwrap_err(),
+            "count",
+            "invalid parameter `count`: expected < 3, got 3",
+        );
+        assert_parameter_error(
+            validate!(count <= 2).unwrap_err(),
+            "count",
+            "invalid parameter `count`: expected <= 2, got 3",
+        );
+
+        let count = 0;
+        assert_parameter_error(
+            validate!(count > 0).unwrap_err(),
+            "count",
+            "invalid parameter `count`: expected > 0, got 0",
+        );
+        assert_parameter_error(
+            validate!(count >= 1).unwrap_err(),
+            "count",
+            "invalid parameter `count`: expected >= 1, got 0",
+        );
+    }
+
+    #[test]
+    fn inclusive_range_checks_identifier_parameters() {
+        let probability = 1.2;
+        let error = validate!(0.0 <= probability <= 1.0).unwrap_err();
+
+        assert_parameter_error(
+            error,
+            "probability",
+            "invalid parameter `probability`: expected in [0.0, 1.0], got 1.2",
+        );
+
+        let probability = 0.5;
+        assert!(validate!(0.0 <= probability <= 1.0).is_ok());
+    }
+
+    #[test]
+    fn range_checks_render_open_and_half_open_intervals() {
+        let probability = 0.0;
+        assert_parameter_error(
+            validate!(0.0 < probability < 1.0).unwrap_err(),
+            "probability",
+            "invalid parameter `probability`: expected in (0.0, 1.0), got 0.0",
+        );
+        assert_parameter_error(
+            validate!(0.0 < probability <= 1.0).unwrap_err(),
+            "probability",
+            "invalid parameter `probability`: expected in (0.0, 1.0], got 0.0",
+        );
+
+        let probability = 1.0;
+        assert_parameter_error(
+            validate!(0.0 <= probability < 1.0).unwrap_err(),
+            "probability",
+            "invalid parameter `probability`: expected in [0.0, 1.0), got 1.0",
+        );
+        assert_parameter_error(
+            validate!(0.0 <= probability <= 0.5).unwrap_err(),
+            "probability",
+            "invalid parameter `probability`: expected in [0.0, 0.5], got 1.0",
+        );
+    }
+
+    #[test]
+    fn range_checks_support_fields_and_negative_literal_bounds() {
+        struct Config {
+            score: f64,
+        }
+
+        let config = Config { score: -1.0 };
+        let error = validate!(-1.0 < config.score <= 1.0).unwrap_err();
+
+        assert_parameter_error(
+            error,
+            "score",
+            "invalid parameter `score`: expected in (-1.0, 1.0], got -1.0",
+        );
+    }
+
+    #[test]
+    fn inclusive_range_accepts_parenthesized_expressions() {
+        let lower = -1.0;
+        let upper = 1.0;
+        let score = 1.5;
+        let error = validate!((lower) < score < (upper)).unwrap_err();
+
+        assert_parameter_error(
+            error,
+            "score",
+            "invalid parameter `score`: expected in (lower, upper), got 1.5",
+        );
+    }
+
+    #[test]
+    fn custom_checks_use_inferred_value_name() {
+        let sigma = f64::NAN;
+        let error = validate!(sigma, sigma.is_finite(), "finite").unwrap_err();
+
+        assert_parameter_error(
+            error,
+            "sigma",
+            "invalid parameter `sigma`: expected finite, got NaN",
+        );
+    }
+
+    #[test]
+    fn custom_checks_can_use_explicit_name() {
+        let config = Some(f64::NAN);
+        let error = validate!(
+            "sigma",
+            config,
+            config.is_some_and(f64::is_finite),
+            "finite"
+        )
+        .unwrap_err();
+
+        assert_parameter_error(
+            error,
+            "sigma",
+            "invalid parameter `sigma`: expected finite, got Some(NaN)",
+        );
+    }
+}

--- a/crates/validate/src/lib.rs
+++ b/crates/validate/src/lib.rs
@@ -48,77 +48,31 @@ impl std::error::Error for ValidationError {}
 /// use validate::{ValidationError, validate};
 ///
 /// fn configure(rate: f64, probability: f64) -> Result<(), ValidationError> {
-///     validate!(rate > 0.0)?;
-///     validate!(0.0 <= probability <= 1.0)?;
-///     validate!(rate, rate.is_finite(), "finite")?;
+///     validate!(rate: > 0.0)?;
+///     validate!(probability: >= 0.0, <= 1.0)?;
+///     validate!(rate: rate.is_finite(); "finite")?;
 ///     Ok(())
 /// }
 /// ```
 #[macro_export]
 macro_rules! validate {
-    // Range with parenthesized expression bounds for a plain identifier:
-    // `validate!((min()) <= probability < (max()))`.
-    (($lower:expr) $lower_operator:tt $name:ident $upper_operator:tt ($upper:expr) $(,)?) => {
-        $crate::validate!(
-            @range (stringify!($name), $name),
-            $lower,
-            $lower_operator,
-            $upper_operator,
-            $upper
-        )
+    // Range checks use comma-separated clauses and render the corresponding interval.
+    // `validate!(config.probability: >= lower(), < upper())`.
+    ($value:ident $(.$field:tt)* : $lower_operator:tt $lower:expr, $upper_operator:tt $upper:expr $(,)?) => {
+        $crate::validate!(@range (
+            stringify!($value $(.$field)*),
+            $value $(.$field)*
+        ), $lower_operator, $lower, $upper_operator, $upper)
     };
-    // Range with parenthesized expression bounds for one field access:
-    // `validate!((min()) <= config.probability < (max()))`.
-    (($lower:expr) $lower_operator:tt $receiver:tt.$field:ident $upper_operator:tt ($upper:expr) $(,)?) => {
-        $crate::validate!(
-            @range (stringify!($field), $receiver.$field),
-            $lower,
-            $lower_operator,
-            $upper_operator,
-            $upper
-        )
+    // Single comparison checks. Bounds are full Rust expressions.
+    // `validate!(config.steps: >= min_steps())`.
+    ($value:ident $(.$field:tt)* : $operator:tt $bound:expr $(,)?) => {
+        $crate::validate!(@cmp (stringify!($value $(.$field)*), $value $(.$field)*), $operator, $bound)
     };
-    // Range with literal bounds for a plain identifier:
-    // `validate!(0.0 <= probability < 1.0)`.
-    ($lower:literal $lower_operator:tt $name:ident $upper_operator:tt $upper:literal $(,)?) => {
-        $crate::validate!(
-            @range (stringify!($name), $name),
-            $lower,
-            $lower_operator,
-            $upper_operator,
-            $upper
-        )
-    };
-    // Range with literal bounds for one field access:
-    // `validate!(0.0 <= config.probability < 1.0)`.
-    ($lower:literal $lower_operator:tt $receiver:tt.$field:ident $upper_operator:tt $upper:literal $(,)?) => {
-        $crate::validate!(
-            @range (stringify!($field), $receiver.$field),
-            $lower,
-            $lower_operator,
-            $upper_operator,
-            $upper
-        )
-    };
-    // Comparison for one field access:
-    // `validate!(config.steps >= 1)`.
-    ($receiver:tt.$field:ident $operator:tt $bound:expr $(,)?) => {
-        $crate::validate!(@cmp (stringify!($field), $receiver.$field), $operator, $bound)
-    };
-    // Comparison for a plain identifier:
-    // `validate!(steps >= 1)`.
-    ($name:ident $operator:tt $bound:expr $(,)?) => {
-        $crate::validate!(@cmp (stringify!($name), $name), $operator, $bound)
-    };
-    // Custom predicate with an explicit diagnostic name:
-    // `validate!("sigma", value, value.is_finite(), "finite")`.
-    ($name:literal, $value:expr, $condition:expr, $expected:expr $(,)?) => {{
-        $crate::validate!(@check $condition, $name, &$value, $expected)
-    }};
-    // Custom predicate that uses the value expression text as the diagnostic name:
-    // `validate!(sigma, sigma.is_finite(), "finite")`.
-    ($value:expr, $condition:expr, $expected:expr $(,)?) => {{
-        $crate::validate!(@check $condition, stringify!($value), &$value, $expected)
+    // Custom predicate that uses the field path text as the diagnostic name:
+    // `validate!(sigma: sigma.is_finite(); "finite")`.
+    ($value:ident $(.$field:tt)* : $condition:expr ; $expected:expr $(,)?) => {{
+        $crate::validate!(@check $condition, stringify!($value $(.$field)*), &$value $(.$field)*, $expected)
     }};
     // Shared comparison implementation. Public comparison arms only extract `(name, value)`;
     // this arm evaluates the value and bound once, then delegates condition checking.
@@ -132,47 +86,46 @@ macro_rules! validate {
             $crate::validate!(@cmp_expected $operator, $bound)
         )
     }};
-    // Shared range implementation. Lower and upper are evaluated once, and the operators decide
-    // whether each side is open or closed.
+    // Shared range implementation. Bounds are evaluated once, and the operators decide whether
+    // each side is open or closed.
     (@range (
         $name:expr,
         $value:expr
-    ), $lower:expr, $lower_operator:tt, $upper_operator:tt, $upper:expr) => {{
+    ), $lower_operator:tt, $lower:expr, $upper_operator:tt, $upper:expr) => {{
         let value = &$value;
         let lower = $lower;
         let upper = $upper;
         $crate::validate!(
-            @check &lower $lower_operator value && value $upper_operator &upper,
+            @check value $lower_operator &lower && value $upper_operator &upper,
             $name,
             value,
             $crate::validate!(@range_expected $lower_operator, $upper_operator, $lower, $upper)
         )
     }};
-    // Render the expected interval text for open and closed range combinations.
-    (@range_expected <, <, $lower:expr, $upper:expr) => {
-        concat!("in (", stringify!($lower), ", ", stringify!($upper), ")")
+    (@range_expected $lower_operator:tt, $upper_operator:tt, $lower:expr, $upper:expr) => {
+        concat!(
+            "in ",
+            $crate::validate!(@lower_bracket $lower_operator),
+            stringify!($lower),
+            ", ",
+            stringify!($upper),
+            $crate::validate!(@upper_bracket $upper_operator)
+        )
     };
-    (@range_expected <, <=, $lower:expr, $upper:expr) => {
-        concat!("in (", stringify!($lower), ", ", stringify!($upper), "]")
+    (@lower_bracket >) => {
+        "("
     };
-    (@range_expected <=, <, $lower:expr, $upper:expr) => {
-        concat!("in [", stringify!($lower), ", ", stringify!($upper), ")")
+    (@lower_bracket >=) => {
+        "["
     };
-    (@range_expected <=, <=, $lower:expr, $upper:expr) => {
-        concat!("in [", stringify!($lower), ", ", stringify!($upper), "]")
+    (@upper_bracket <) => {
+        ")"
     };
-    // Render the expected comparison text for the supported comparison operators.
-    (@cmp_expected >, $bound:expr) => {
-        concat!("> ", stringify!($bound))
+    (@upper_bracket <=) => {
+        "]"
     };
-    (@cmp_expected >=, $bound:expr) => {
-        concat!(">= ", stringify!($bound))
-    };
-    (@cmp_expected <, $bound:expr) => {
-        concat!("< ", stringify!($bound))
-    };
-    (@cmp_expected <=, $bound:expr) => {
-        concat!("<= ", stringify!($bound))
+    (@cmp_expected $operator:tt, $bound:expr) => {
+        concat!(stringify!($operator), " ", stringify!($bound))
     };
     // Convert a boolean validation result into `Result<(), ValidationError>`.
     (@check $condition:expr, $name:expr, $value:expr, $expected:expr) => {{
@@ -215,7 +168,7 @@ mod tests {
     #[test]
     fn comparison_checks_identifier_parameters() {
         let rate = -0.1;
-        let error = validate!(rate > 0.0).unwrap_err();
+        let error = validate!(rate: > 0.0).unwrap_err();
 
         assert_validation_error(
             error,
@@ -224,22 +177,40 @@ mod tests {
         );
 
         let rate = 0.1;
-        assert!(validate!(rate > 0.0).is_ok());
+        assert!(validate!(rate: > 0.0).is_ok());
     }
 
     #[test]
-    fn comparison_checks_field_parameters() {
-        struct Config {
+    fn comparison_checks_field_paths() {
+        struct Inner {
             steps: usize,
         }
 
-        let config = Config { steps: 0 };
-        let error = validate!(config.steps >= 1).unwrap_err();
+        struct Config {
+            inner: Inner,
+        }
+
+        let config = Config {
+            inner: Inner { steps: 0 },
+        };
+        let error = validate!(config.inner.steps: >= 1).unwrap_err();
 
         assert_validation_error(
             error,
-            "steps",
-            "invalid parameter `steps`: expected >= 1, got 0",
+            "config.inner.steps",
+            "invalid parameter `config.inner.steps`: expected >= 1, got 0",
+        );
+    }
+
+    #[test]
+    fn comparison_checks_tuple_field_paths() {
+        let config = (0,);
+        let error = validate!(config.0: >= 1).unwrap_err();
+
+        assert_validation_error(
+            error,
+            "config.0",
+            "invalid parameter `config.0`: expected >= 1, got 0",
         );
     }
 
@@ -251,7 +222,7 @@ mod tests {
 
         impl Config {
             fn validate(&self) -> Result<(), ValidationError> {
-                validate!(self.rate > 0.0)
+                validate!(self.rate: > 0.0)
             }
         }
 
@@ -259,8 +230,8 @@ mod tests {
 
         assert_validation_error(
             error,
-            "rate",
-            "invalid parameter `rate`: expected > 0.0, got 0.0",
+            "self.rate",
+            "invalid parameter `self.rate`: expected > 0.0, got 0.0",
         );
     }
 
@@ -268,24 +239,24 @@ mod tests {
     fn comparison_checks_render_each_supported_operator() {
         let count = 3;
         assert_validation_error(
-            validate!(count < 3).unwrap_err(),
+            validate!(count: < 3).unwrap_err(),
             "count",
             "invalid parameter `count`: expected < 3, got 3",
         );
         assert_validation_error(
-            validate!(count <= 2).unwrap_err(),
+            validate!(count: <= 2).unwrap_err(),
             "count",
             "invalid parameter `count`: expected <= 2, got 3",
         );
 
         let count = 0;
         assert_validation_error(
-            validate!(count > 0).unwrap_err(),
+            validate!(count: > 0).unwrap_err(),
             "count",
             "invalid parameter `count`: expected > 0, got 0",
         );
         assert_validation_error(
-            validate!(count >= 1).unwrap_err(),
+            validate!(count: >= 1).unwrap_err(),
             "count",
             "invalid parameter `count`: expected >= 1, got 0",
         );
@@ -294,7 +265,7 @@ mod tests {
     #[test]
     fn inclusive_range_checks_identifier_parameters() {
         let probability = 1.2;
-        let error = validate!(0.0 <= probability <= 1.0).unwrap_err();
+        let error = validate!(probability: >= 0.0, <= 1.0).unwrap_err();
 
         assert_validation_error(
             error,
@@ -303,31 +274,31 @@ mod tests {
         );
 
         let probability = 0.5;
-        assert!(validate!(0.0 <= probability <= 1.0).is_ok());
+        assert!(validate!(probability: >= 0.0, <= 1.0).is_ok());
     }
 
     #[test]
     fn range_checks_render_open_and_half_open_intervals() {
         let probability = 0.0;
         assert_validation_error(
-            validate!(0.0 < probability < 1.0).unwrap_err(),
+            validate!(probability: > 0.0, < 1.0).unwrap_err(),
             "probability",
             "invalid parameter `probability`: expected in (0.0, 1.0), got 0.0",
         );
         assert_validation_error(
-            validate!(0.0 < probability <= 1.0).unwrap_err(),
+            validate!(probability: > 0.0, <= 1.0).unwrap_err(),
             "probability",
             "invalid parameter `probability`: expected in (0.0, 1.0], got 0.0",
         );
 
         let probability = 1.0;
         assert_validation_error(
-            validate!(0.0 <= probability < 1.0).unwrap_err(),
+            validate!(probability: >= 0.0, < 1.0).unwrap_err(),
             "probability",
             "invalid parameter `probability`: expected in [0.0, 1.0), got 1.0",
         );
         assert_validation_error(
-            validate!(0.0 <= probability <= 0.5).unwrap_err(),
+            validate!(probability: >= 0.0, <= 0.5).unwrap_err(),
             "probability",
             "invalid parameter `probability`: expected in [0.0, 0.5], got 1.0",
         );
@@ -340,56 +311,38 @@ mod tests {
         }
 
         let config = Config { score: -1.0 };
-        let error = validate!(-1.0 < config.score <= 1.0).unwrap_err();
+        let error = validate!(config.score: > -1.0, <= 1.0).unwrap_err();
 
         assert_validation_error(
             error,
-            "score",
-            "invalid parameter `score`: expected in (-1.0, 1.0], got -1.0",
+            "config.score",
+            "invalid parameter `config.score`: expected in (-1.0, 1.0], got -1.0",
         );
     }
 
     #[test]
-    fn inclusive_range_accepts_parenthesized_expressions() {
-        let lower = -1.0;
-        let upper = 1.0;
+    fn range_accepts_expression_bounds() {
+        let lower = -2.0;
+        let upper = 2.0;
         let score = 1.5;
-        let error = validate!((lower) < score < (upper)).unwrap_err();
+        let error = validate!(score: > lower + 1.0, < upper - 1.0).unwrap_err();
 
         assert_validation_error(
             error,
             "score",
-            "invalid parameter `score`: expected in (lower, upper), got 1.5",
+            "invalid parameter `score`: expected in (lower + 1.0, upper - 1.0), got 1.5",
         );
     }
 
     #[test]
     fn custom_checks_use_inferred_value_name() {
         let sigma = f64::NAN;
-        let error = validate!(sigma, sigma.is_finite(), "finite").unwrap_err();
+        let error = validate!(sigma: sigma.is_finite(); "finite").unwrap_err();
 
         assert_validation_error(
             error,
             "sigma",
             "invalid parameter `sigma`: expected finite, got NaN",
-        );
-    }
-
-    #[test]
-    fn custom_checks_can_use_explicit_name() {
-        let config = Some(f64::NAN);
-        let error = validate!(
-            "sigma",
-            config,
-            config.is_some_and(f64::is_finite),
-            "finite"
-        )
-        .unwrap_err();
-
-        assert_validation_error(
-            error,
-            "sigma",
-            "invalid parameter `sigma`: expected finite, got Some(NaN)",
         );
     }
 }

--- a/crates/validate/src/lib.rs
+++ b/crates/validate/src/lib.rs
@@ -334,18 +334,6 @@ mod tests {
     }
 
     #[test]
-    fn range_checks_tuple_field_paths() {
-        let config = (1.5,);
-        let error = validate!(config.0: >= 0.0, <= 1.0).unwrap_err();
-
-        assert_validation_error(
-            error,
-            "config.0",
-            "invalid parameter `config.0`: expected in [0.0, 1.0], got 1.5",
-        );
-    }
-
-    #[test]
     fn range_accepts_expression_bounds() {
         let lower = -2.0;
         let upper = 2.0;

--- a/crates/validate/src/lib.rs
+++ b/crates/validate/src/lib.rs
@@ -3,16 +3,16 @@
 
 /// Error returned when a parameter fails validation.
 ///
-/// The full diagnostic is available through [`std::fmt::Display`]. Use [`ParameterError::name`]
+/// The full diagnostic is available through [`std::fmt::Display`]. Use [`ValidationError::name`]
 /// when you need the failing parameter name separately.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ParameterError {
+pub struct ValidationError {
     name: &'static str,
     value: String,
     expected: &'static str,
 }
 
-impl ParameterError {
+impl ValidationError {
     /// Return the name of the parameter that failed validation.
     pub const fn name(&self) -> &'static str {
         self.name
@@ -28,7 +28,7 @@ impl ParameterError {
     }
 }
 
-impl std::fmt::Display for ParameterError {
+impl std::fmt::Display for ValidationError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
@@ -38,16 +38,16 @@ impl std::fmt::Display for ParameterError {
     }
 }
 
-impl std::error::Error for ParameterError {}
+impl std::error::Error for ValidationError {}
 
-/// Validate a parameter and return [`ParameterError`] on failure.
+/// Validate a parameter and return [`ValidationError`] on failure.
 ///
 /// # Examples
 ///
 /// ```
-/// use validate::{ParameterError, validate};
+/// use validate::{ValidationError, validate};
 ///
-/// fn configure(rate: f64, probability: f64) -> Result<(), ParameterError> {
+/// fn configure(rate: f64, probability: f64) -> Result<(), ValidationError> {
 ///     validate!(rate > 0.0)?;
 ///     validate!(0.0 <= probability <= 1.0)?;
 ///     validate!(rate, rate.is_finite(), "finite")?;
@@ -174,7 +174,7 @@ macro_rules! validate {
     (@cmp_expected <=, $bound:expr) => {
         concat!("<= ", stringify!($bound))
     };
-    // Convert a boolean validation result into `Result<(), ParameterError>`.
+    // Convert a boolean validation result into `Result<(), ValidationError>`.
     (@check $condition:expr, $name:expr, $value:expr, $expected:expr) => {{
         if $condition {
             ::core::result::Result::Ok(())
@@ -184,7 +184,7 @@ macro_rules! validate {
     }};
     // Build the diagnostic error. The value is formatted only on the failure path.
     (@invalid $name:expr, $value:expr, $expected:expr) => {
-        ::core::result::Result::Err($crate::ParameterError::__new(
+        ::core::result::Result::Err($crate::ValidationError::__new(
             $name,
             ::std::format!("{:?}", $value),
             $expected,
@@ -197,14 +197,14 @@ macro_rules! validate {
 mod tests {
     use super::*;
 
-    fn assert_parameter_error(error: ParameterError, name: &'static str, display: &str) {
+    fn assert_validation_error(error: ValidationError, name: &'static str, display: &str) {
         assert_eq!(error.name(), name);
         assert_eq!(error.to_string(), display);
     }
 
     #[test]
     fn display_orders_expected_before_actual_value() {
-        let error = ParameterError::__new("rate", "-1.0".to_owned(), "> 0.0");
+        let error = ValidationError::__new("rate", "-1.0".to_owned(), "> 0.0");
 
         assert_eq!(
             error.to_string(),
@@ -217,7 +217,7 @@ mod tests {
         let rate = -0.1;
         let error = validate!(rate > 0.0).unwrap_err();
 
-        assert_parameter_error(
+        assert_validation_error(
             error,
             "rate",
             "invalid parameter `rate`: expected > 0.0, got -0.1",
@@ -236,7 +236,7 @@ mod tests {
         let config = Config { steps: 0 };
         let error = validate!(config.steps >= 1).unwrap_err();
 
-        assert_parameter_error(
+        assert_validation_error(
             error,
             "steps",
             "invalid parameter `steps`: expected >= 1, got 0",
@@ -250,14 +250,14 @@ mod tests {
         }
 
         impl Config {
-            fn validate(&self) -> Result<(), ParameterError> {
+            fn validate(&self) -> Result<(), ValidationError> {
                 validate!(self.rate > 0.0)
             }
         }
 
         let error = Config { rate: 0.0 }.validate().unwrap_err();
 
-        assert_parameter_error(
+        assert_validation_error(
             error,
             "rate",
             "invalid parameter `rate`: expected > 0.0, got 0.0",
@@ -267,24 +267,24 @@ mod tests {
     #[test]
     fn comparison_checks_render_each_supported_operator() {
         let count = 3;
-        assert_parameter_error(
+        assert_validation_error(
             validate!(count < 3).unwrap_err(),
             "count",
             "invalid parameter `count`: expected < 3, got 3",
         );
-        assert_parameter_error(
+        assert_validation_error(
             validate!(count <= 2).unwrap_err(),
             "count",
             "invalid parameter `count`: expected <= 2, got 3",
         );
 
         let count = 0;
-        assert_parameter_error(
+        assert_validation_error(
             validate!(count > 0).unwrap_err(),
             "count",
             "invalid parameter `count`: expected > 0, got 0",
         );
-        assert_parameter_error(
+        assert_validation_error(
             validate!(count >= 1).unwrap_err(),
             "count",
             "invalid parameter `count`: expected >= 1, got 0",
@@ -296,7 +296,7 @@ mod tests {
         let probability = 1.2;
         let error = validate!(0.0 <= probability <= 1.0).unwrap_err();
 
-        assert_parameter_error(
+        assert_validation_error(
             error,
             "probability",
             "invalid parameter `probability`: expected in [0.0, 1.0], got 1.2",
@@ -309,24 +309,24 @@ mod tests {
     #[test]
     fn range_checks_render_open_and_half_open_intervals() {
         let probability = 0.0;
-        assert_parameter_error(
+        assert_validation_error(
             validate!(0.0 < probability < 1.0).unwrap_err(),
             "probability",
             "invalid parameter `probability`: expected in (0.0, 1.0), got 0.0",
         );
-        assert_parameter_error(
+        assert_validation_error(
             validate!(0.0 < probability <= 1.0).unwrap_err(),
             "probability",
             "invalid parameter `probability`: expected in (0.0, 1.0], got 0.0",
         );
 
         let probability = 1.0;
-        assert_parameter_error(
+        assert_validation_error(
             validate!(0.0 <= probability < 1.0).unwrap_err(),
             "probability",
             "invalid parameter `probability`: expected in [0.0, 1.0), got 1.0",
         );
-        assert_parameter_error(
+        assert_validation_error(
             validate!(0.0 <= probability <= 0.5).unwrap_err(),
             "probability",
             "invalid parameter `probability`: expected in [0.0, 0.5], got 1.0",
@@ -342,7 +342,7 @@ mod tests {
         let config = Config { score: -1.0 };
         let error = validate!(-1.0 < config.score <= 1.0).unwrap_err();
 
-        assert_parameter_error(
+        assert_validation_error(
             error,
             "score",
             "invalid parameter `score`: expected in (-1.0, 1.0], got -1.0",
@@ -356,7 +356,7 @@ mod tests {
         let score = 1.5;
         let error = validate!((lower) < score < (upper)).unwrap_err();
 
-        assert_parameter_error(
+        assert_validation_error(
             error,
             "score",
             "invalid parameter `score`: expected in (lower, upper), got 1.5",
@@ -368,7 +368,7 @@ mod tests {
         let sigma = f64::NAN;
         let error = validate!(sigma, sigma.is_finite(), "finite").unwrap_err();
 
-        assert_parameter_error(
+        assert_validation_error(
             error,
             "sigma",
             "invalid parameter `sigma`: expected finite, got NaN",
@@ -386,7 +386,7 @@ mod tests {
         )
         .unwrap_err();
 
-        assert_parameter_error(
+        assert_validation_error(
             error,
             "sigma",
             "invalid parameter `sigma`: expected finite, got Some(NaN)",


### PR DESCRIPTION
## Summary

Add a small `validate` crate for parameter validation with structured diagnostics and a macro syntax centered on an explicit validation subject.

## Changes

- Add `ValidationError` with `Display`, `Error`, and parameter-name access.
- Add `validate!` forms for comparisons, comma-separated ranges, and custom predicates.
- Support identifier, named-field, tuple-field, and `self` field subjects with full-expression bounds.
- Document supported forms and cover macro behavior with unit and doctests.

## Validation

- `cargo test -p validate`
- `cargo clippy -p validate --all-targets -- -D warnings`
- `cargo +nightly fmt --check --package validate`
- `cargo check`
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `cargo +nightly fmt --check`
- `cargo +nightly llvm-cov`