### PR TITLE
[codex] add diagnostic aliases to validate macro

### DIFF
--- a/crates/validate/README.md
+++ b/crates/validate/README.md
@@ -71,3 +71,15 @@ Custom checks use `;` to separate an arbitrary boolean expression from its stati
 validate!(sigma: sigma.is_finite(); "finite")?;
 # Ok::<(), ValidationError>(())
 ```
+
+When the checked value is a field path but the diagnostic should use a shorter user-facing name or field path, add an explicit `as diagnostic_name` or `as diagnostic.path` before `:`. This override affects only `ValidationError::name()` and the rendered diagnostic; the checked value remains the full field path.
+
+```rust
+# use validate::{ValidationError, validate};
+# struct Config { rate: f64, probability: f64 }
+# let config = Config { rate: 0.5, probability: 0.5 };
+validate!(config.rate as rate: > 0.0)?;
+validate!(config.probability as parameters.probability: >= 0.0, <= 1.0)?;
+validate!(config.rate as rate: config.rate.is_finite(); "finite")?;
+# Ok::<(), ValidationError>(())
+```

--- a/crates/validate/src/lib.rs
+++ b/crates/validate/src/lib.rs
@@ -56,25 +56,37 @@ impl std::error::Error for ValidationError {}
 /// ```
 #[macro_export]
 macro_rules! validate {
-    // Range checks use comma-separated clauses and render the corresponding interval.
-    // `validate!(config.probability: >= lower(), < upper())`.
-    ($value:ident $(.$field:tt)* : $lower_operator:tt $lower:expr, $upper_operator:tt $upper:expr $(,)?) => {
-        $crate::validate!(@range (
+    // Explicit diagnostic aliases keep the checked field path separate from the reported name.
+    // `validate!(self.probability as probability: >= lower(), <= upper())`.
+    ($value:ident $(.$field:tt)* as $name:ident $(.$name_field:tt)* : $($rule:tt)+) => {
+        $crate::validate!(@named (
+            stringify!($name $(.$name_field)*),
+            $value $(.$field)*
+        ): $($rule)+)
+    };
+    // Without an explicit alias, the field path text is the diagnostic name.
+    ($value:ident $(.$field:tt)* : $($rule:tt)+) => {
+        $crate::validate!(@named (
             stringify!($value $(.$field)*),
             $value $(.$field)*
-        ), $lower_operator, $lower, $upper_operator, $upper)
+        ): $($rule)+)
+    };
+    // Range checks use comma-separated clauses and render the corresponding interval.
+    // `validate!(config.probability: >= lower(), < upper())`.
+    (@named ($name:expr, $value:expr): $lower_operator:tt $lower:expr, $upper_operator:tt $upper:expr $(,)?) => {
+        $crate::validate!(@range ($name, $value), $lower_operator, $lower, $upper_operator, $upper)
     };
     // Single comparison checks. Bounds are full Rust expressions.
     // `validate!(config.steps: >= min_steps())`.
-    ($value:ident $(.$field:tt)* : $operator:tt $bound:expr $(,)?) => {
-        $crate::validate!(@cmp (stringify!($value $(.$field)*), $value $(.$field)*), $operator, $bound)
+    (@named ($name:expr, $value:expr): $operator:tt $bound:expr $(,)?) => {
+        $crate::validate!(@cmp ($name, $value), $operator, $bound)
     };
-    // Custom predicate that uses the field path text as the diagnostic name:
+    // Custom predicate.
     // `validate!(sigma: sigma.is_finite(); "finite")`.
-    ($value:ident $(.$field:tt)* : $condition:expr ; $expected:expr $(,)?) => {{
-        $crate::validate!(@check $condition, stringify!($value $(.$field)*), &$value $(.$field)*, $expected)
+    (@named ($name:expr, $value:expr): $condition:expr ; $expected:expr $(,)?) => {{
+        $crate::validate!(@check $condition, $name, &$value, $expected)
     }};
-    // Shared comparison implementation. Public comparison arms only extract `(name, value)`;
+    // Shared comparison implementation. Front-end arms only extract `(name, value)`;
     // this arm evaluates the value and bound once, then delegates condition checking.
     (@cmp ($name:expr, $value:expr), $operator:tt, $bound:expr) => {{
         let value = &$value;
@@ -399,6 +411,54 @@ mod tests {
             error,
             "config.inner.sigma",
             "invalid parameter `config.inner.sigma`: expected finite, got NaN",
+        );
+    }
+
+    #[test]
+    fn explicit_diagnostic_names_override_field_paths() {
+        struct Inner {
+            probability: f64,
+        }
+
+        struct Config {
+            inner: Inner,
+            rate: f64,
+        }
+
+        impl Config {
+            fn validate_rate(&self) -> Result<(), ValidationError> {
+                validate!(self.rate as rate: > 0.0)
+            }
+
+            fn validate_finite_rate(&self) -> Result<(), ValidationError> {
+                validate!(self.rate as rate: self.rate.is_finite(); "finite")
+            }
+        }
+
+        let config = Config {
+            inner: Inner { probability: 1.2 },
+            rate: f64::NAN,
+        };
+
+        assert_validation_error(
+            config.validate_rate().unwrap_err(),
+            "rate",
+            "invalid parameter `rate`: expected > 0.0, got NaN",
+        );
+        assert_validation_error(
+            validate!(config.inner.probability as probability: >= 0.0, <= 1.0).unwrap_err(),
+            "probability",
+            "invalid parameter `probability`: expected in [0.0, 1.0], got 1.2",
+        );
+        assert_validation_error(
+            config.validate_finite_rate().unwrap_err(),
+            "rate",
+            "invalid parameter `rate`: expected finite, got NaN",
+        );
+        assert_validation_error(
+            validate!(config.rate as parameters.rate: > 0.0).unwrap_err(),
+            "parameters.rate",
+            "invalid parameter `parameters.rate`: expected > 0.0, got NaN",
         );
     }
 }


### PR DESCRIPTION
## Summary

- Add explicit diagnostic aliases to the `validate!` macro using `as name` and `as dotted.path` syntax.
- Route aliased and default validation forms through a shared `@named` macro path for comparison, range, and custom predicate checks.
- Document the new syntax and cover comparison, range, custom predicate, and dotted diagnostic alias behavior in tests.

## Why

`validate!` previously derived the reported parameter name only from the checked value path. That made internal field paths like `self.division_rate_max` leak into user-facing diagnostics unless callers introduced temporary local variables. The new syntax keeps the actual checked value explicit while allowing the diagnostic name to be user-facing.

## Validation

- `cargo +nightly fmt`
- `cargo test -p validate`
- `cargo clippy -p validate --all-targets -- -D warnings`
- `cargo check`
- `git diff --check`
