### PR TITLE
[codex] Add repeated stochastic input batches

### DIFF
--- a/crates/ssa-workflow/README.md
+++ b/crates/ssa-workflow/README.md
@@ -85,13 +85,15 @@ fn main() -> ssa_workflow::error::Result<()> {
         .build()?;
 
     // Same parameter set, eight independent stochastic repetitions.
-    let inputs: Vec<_> = (0..8u64)
-        .map(|rep| StochasticInput::new((25u32, 100u32), rep))
-        .collect();
+    let repetitions = 8;
 
     // Execution is demand-driven: cache misses compute, hits reuse stored results.
-    let first_run = peak_population.with_inputs(inputs.clone()).collect()?;
-    let second_run = peak_population.with_inputs(inputs).collect()?;
+    let first_run = peak_population
+        .with_repeated_input((25u32, 100u32), repetitions)
+        .collect()?;
+    let second_run = peak_population
+        .with_repeated_input((25u32, 100u32), repetitions)
+        .collect()?;
 
     assert_eq!(first_run, second_run);
     Ok(())
@@ -100,7 +102,7 @@ fn main() -> ssa_workflow::error::Result<()> {
 
 ## Core Concepts
 
-- `StochasticTask` runs a simulation with reproducible RNG streams. Each `StochasticInput<P>` combines a parameter value with a `repetition_index`.
+- `StochasticTask` runs a simulation with reproducible RNG streams. Each `StochasticInput<P>` combines a parameter value with a `repetition_index`; use `.with_repeated_input(param, repetitions)` for the common same-parameter batch case.
 - `DeterministicTask` runs a pure `input -> output` root computation.
 - `.transform(...)` builds a dependent deterministic analysis from an upstream task or transform.
 - `.stochastic_transform(...)` builds a dependent stochastic analysis from an upstream result.

--- a/crates/ssa-workflow/src/compute/mod.rs
+++ b/crates/ssa-workflow/src/compute/mod.rs
@@ -8,7 +8,7 @@ pub mod transform;
 
 pub use deterministic::DeterministicTask;
 pub use execution::{BatchExecution, Compute, InterruptSignal};
-pub use stochastic::{StochasticInput, StochasticTask};
+pub use stochastic::{StochasticComputeExt, StochasticInput, StochasticTask};
 pub use stream::{
     MultiStreams, RandomVariable, RngBundle, SeedSource, SingleStream, StreamSeed, StreamSeeds,
 };

--- a/crates/ssa-workflow/src/compute/stochastic/mod.rs
+++ b/crates/ssa-workflow/src/compute/stochastic/mod.rs
@@ -113,8 +113,10 @@
 
 use std::marker::PhantomData;
 
+use rayon::prelude::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};
+
 use crate::{
-    Compute, Result,
+    BatchExecution, Compute, Result,
     cache::{Cache, CacheProvider, CanonicalEncode, CloneShared},
     compute::{
         NoFunction,
@@ -176,6 +178,40 @@ impl<P: CanonicalEncode> CanonicalEncode for StochasticInput<P> {
         }
     }
 }
+
+/// Convenience methods for computations keyed by [`StochasticInput`].
+///
+/// This trait is implemented for every [`Compute`] node, including stochastic tasks and
+/// deterministic transforms built from stochastic tasks. Import it from the prelude to run the
+/// common "same deterministic input, many stochastic repetitions" batch without manually building
+/// `StochasticInput` values.
+pub trait StochasticComputeExt: Compute {
+    /// Start a batch execution for `repetitions` stochastic repetitions of one deterministic input.
+    ///
+    /// The batch uses `0..repetitions` as its indexed parallel input range and converts each item
+    /// to `StochasticInput::new(param.clone(), index as u64)`. Collected outputs therefore
+    /// remain in repetition-index order while the stochastic identity continues to use a
+    /// platform-stable `u64` repetition id.
+    fn with_repeated_input<P>(
+        &self,
+        param: P,
+        repetitions: usize,
+    ) -> BatchExecution<'_, Self, impl IndexedParallelIterator<Item = StochasticInput<P>>>
+    where
+        Self: Sized + Compute<Input = StochasticInput<P>>,
+        P: Clone + Send,
+    {
+        self.with_inputs(
+            (0..repetitions)
+                .into_par_iter()
+                .map_with(param, |param, index| {
+                    StochasticInput::new(param.clone(), index as u64)
+                }),
+        )
+    }
+}
+
+impl<T: Compute> StochasticComputeExt for T {}
 
 /// Memoized stochastic task with reproducible randomness.
 ///

--- a/crates/ssa-workflow/src/prelude.rs
+++ b/crates/ssa-workflow/src/prelude.rs
@@ -19,6 +19,7 @@ pub use crate::{
     cache::{CanonicalEncode, StorageProviderExt, memory::ManagedHashCache},
     compute::{
         DependentInput, DependentStochasticInput, DeterministicTask, RandomVariable, RngBundle,
-        StochasticInput, StochasticTask, StochasticTransform, Transform, TransformExt,
+        StochasticComputeExt, StochasticInput, StochasticTask, StochasticTransform, Transform,
+        TransformExt,
     },
 };

--- a/crates/ssa-workflow/tests/execution_integration.rs
+++ b/crates/ssa-workflow/tests/execution_integration.rs
@@ -4,7 +4,44 @@ use std::sync::{
 };
 
 use rand::Rng;
-use ssa_workflow::{error::Result, prelude::*};
+use ssa_workflow::{
+    cache::{Cache, CacheProvider, CloneShared},
+    error::Result,
+    identity::ComputationPath,
+    prelude::*,
+};
+
+#[derive(Clone, Copy)]
+struct RepetitionIndexProvider;
+
+#[derive(Clone, Copy)]
+struct RepetitionIndexCache;
+
+impl CacheProvider<u64> for RepetitionIndexProvider {
+    type Cache = RepetitionIndexCache;
+
+    fn bind(self, _path: &ComputationPath) -> Result<Self::Cache> {
+        Ok(RepetitionIndexCache)
+    }
+}
+
+impl CloneShared for RepetitionIndexCache {
+    fn clone_shared(&self) -> Self {
+        *self
+    }
+}
+
+impl Cache<u64> for RepetitionIndexCache {
+    fn fetch(&mut self, key: &[u8]) -> Result<Option<u64>> {
+        let mut repetition_bytes = [0u8; u64::SIZE];
+        repetition_bytes.copy_from_slice(&key[key.len() - u64::SIZE..]);
+        Ok(Some(u64::from_be_bytes(repetition_bytes)))
+    }
+
+    fn store(&mut self, _key: &[u8], _value: &u64) -> Result<()> {
+        Ok(())
+    }
+}
 
 #[test]
 fn prelude_smoke_supports_execute_one_and_batch_collect() -> Result<()> {
@@ -25,6 +62,39 @@ fn prelude_smoke_supports_execute_one_and_batch_collect() -> Result<()> {
 
     assert_eq!(outputs, vec![0, 4, 8, 12]);
     assert_eq!(call_count.load(Ordering::SeqCst), 4);
+    Ok(())
+}
+
+#[test]
+fn stochastic_repeated_input_collects_in_repetition_order() -> Result<()> {
+    let task = StochasticTask::builder("repeated-input-order-v1")
+        .function(|_, _: u32| Ok(u64::MAX))
+        .cache(RepetitionIndexProvider)
+        .build()?;
+
+    let outputs: Vec<u64> = task.with_repeated_input(42u32, 5).collect()?;
+
+    assert_eq!(outputs, vec![0, 1, 2, 3, 4]);
+    Ok(())
+}
+
+#[test]
+fn stochastic_repeated_input_zero_repetitions_is_empty() -> Result<()> {
+    let call_count = Arc::new(AtomicUsize::new(0));
+    let call_count_clone = Arc::clone(&call_count);
+
+    let task = StochasticTask::builder("repeated-input-zero-v1")
+        .function(move |rng, ()| {
+            call_count_clone.fetch_add(1, Ordering::SeqCst);
+            Ok(rng.next_u64())
+        })
+        .cache(ManagedHashCache::<u64>::default())
+        .build()?;
+
+    let outputs: Vec<u64> = task.with_repeated_input((), 0).collect()?;
+
+    assert!(outputs.is_empty());
+    assert_eq!(call_count.load(Ordering::SeqCst), 0);
     Ok(())
 }
 
@@ -50,20 +120,18 @@ fn stochastic_transform_reuses_cached_analysis() -> Result<()> {
         .cache(ManagedHashCache::<u32>::default())
         .build()?;
 
-    let inputs: Vec<_> = (0..8u64)
-        .map(|repetition| StochasticInput::new((), repetition))
-        .collect();
+    let repetitions = 8;
 
-    let results1: Vec<u32> = transform.with_inputs(inputs.clone()).collect()?;
+    let results1: Vec<u32> = transform.with_repeated_input((), repetitions).collect()?;
 
-    assert_eq!(results1.len(), inputs.len());
-    assert_eq!(experiment_calls.load(Ordering::SeqCst), inputs.len());
-    assert_eq!(analysis_calls.load(Ordering::SeqCst), inputs.len());
+    assert_eq!(results1.len(), repetitions);
+    assert_eq!(experiment_calls.load(Ordering::SeqCst), repetitions);
+    assert_eq!(analysis_calls.load(Ordering::SeqCst), repetitions);
 
-    let results2: Vec<u32> = transform.with_inputs(inputs).collect()?;
+    let results2: Vec<u32> = transform.with_repeated_input((), repetitions).collect()?;
 
     assert_eq!(results1, results2);
-    assert_eq!(experiment_calls.load(Ordering::SeqCst), 8);
-    assert_eq!(analysis_calls.load(Ordering::SeqCst), 8);
+    assert_eq!(experiment_calls.load(Ordering::SeqCst), repetitions);
+    assert_eq!(analysis_calls.load(Ordering::SeqCst), repetitions);
     Ok(())
 }

--- a/crates/ssa-workflow/tests/ssa_workflow.rs
+++ b/crates/ssa-workflow/tests/ssa_workflow.rs
@@ -77,12 +77,11 @@ fn birth_death_ssa_transform_is_reproducible_and_cached() -> Result<()> {
         .cache(ManagedHashCache::<SsaSummary>::default())
         .build()?;
 
-    let inputs: Vec<_> = (0..16)
-        .map(|repetition| StochasticInput::new((INITIAL_CELLS, MAX_EVENTS), repetition))
-        .collect();
-    let input_count = inputs.len();
+    let input_count = 16;
 
-    let first_run: Vec<SsaSummary> = transform.with_inputs(inputs.clone()).collect()?;
+    let first_run: Vec<SsaSummary> = transform
+        .with_repeated_input((INITIAL_CELLS, MAX_EVENTS), input_count)
+        .collect()?;
 
     assert_eq!(first_run.len(), input_count);
     assert!(first_run.iter().all(|summary| summary.events <= MAX_EVENTS));
@@ -94,7 +93,9 @@ fn birth_death_ssa_transform_is_reproducible_and_cached() -> Result<()> {
     assert_eq!(ssa_calls.load(Ordering::SeqCst), input_count);
     assert_eq!(summary_calls.load(Ordering::SeqCst), input_count);
 
-    let second_run: Vec<SsaSummary> = transform.with_inputs(inputs).collect()?;
+    let second_run: Vec<SsaSummary> = transform
+        .with_repeated_input((INITIAL_CELLS, MAX_EVENTS), input_count)
+        .collect()?;
 
     assert_eq!(first_run, second_run);
     assert_eq!(ssa_calls.load(Ordering::SeqCst), input_count);


### PR DESCRIPTION
## What changed

- Added `StochasticComputeExt::with_repeated_input(param, repetitions)` for `Compute<Input = StochasticInput<P>>` nodes.
- Re-exported the extension trait through `ssa_workflow::compute` and the prelude.
- Updated README and integration examples to use the convenience API.
- Added tests for repetition count, repetition-order output, cache identity reuse, and zero repetitions.

## Why

`StochasticInput` correctly stores `repetition_index` as `u64` for stable RNG/cache identity, but common batch execution works over Rayon indexed ranges, which are naturally `usize`. This API hides that conversion at the library boundary while keeping the existing `BatchExecution` path and identity semantics intact.

## Validation

- `cargo +nightly fmt`
- `cargo test -p ssa-workflow`
- `cargo clippy -p ssa-workflow --all-targets -- -D warnings`