### PR TITLE
feat(ssa-workflow): add configurable batch scheduling

### DIFF
--- a/crates/ssa-workflow/README.md
+++ b/crates/ssa-workflow/README.md
@@ -90,10 +90,10 @@ fn main() -> ssa_workflow::error::Result<()> {
     // Execution is demand-driven: cache misses compute, hits reuse stored results.
     let first_run = peak_population
         .with_repeated_input((25u32, 100u32), repetitions)
-        .collect()?;
+        .collect::<ssa_workflow::Result<Vec<_>>>()?;
     let second_run = peak_population
         .with_repeated_input((25u32, 100u32), repetitions)
-        .collect()?;
+        .collect::<ssa_workflow::Result<Vec<_>>>()?;
 
     assert_eq!(first_run, second_run);
     Ok(())
@@ -102,6 +102,7 @@ fn main() -> ssa_workflow::error::Result<()> {
 
 ## Core Concepts
 
+- `BatchExecution::collect` runs in the current Rayon pool; use `collect_in` for a specified pool and `collect_serial` for caller-thread execution. Collect into `Result<Vec<_>>` to stop on errors or `Vec<Result<_>>` to retain every item result.
 - `StochasticTask` runs a simulation with reproducible RNG streams. Each `StochasticInput<P>` combines a parameter value with a `repetition_index`; use `.with_repeated_input(param, repetitions)` for the common same-parameter batch case.
 - `DeterministicTask` runs a pure `input -> output` root computation.
 - `.transform(...)` builds a dependent deterministic analysis from an upstream task or transform.

--- a/crates/ssa-workflow/README.md
+++ b/crates/ssa-workflow/README.md
@@ -102,8 +102,8 @@ fn main() -> ssa_workflow::error::Result<()> {
 
 ## Core Concepts
 
-- `BatchExecution::collect` runs in the current Rayon pool; use `collect_in` for a specified pool and `collect_serial` for caller-thread execution. Collect into `Result<Vec<_>>` to stop on errors or `Vec<Result<_>>` to retain every item result.
-- `StochasticTask` runs a simulation with reproducible RNG streams. Each `StochasticInput<P>` combines a parameter value with a `repetition_index`; use `.with_repeated_input(param, repetitions)` for the common same-parameter batch case.
+- `BatchExecution::collect` runs in the current Rayon pool, or the global pool when called outside one; use `collect_in` for a specified pool and `collect_serial` for caller-thread execution. Collect into `Result<Vec<_>>` to stop on errors or `Vec<Result<_>>` to retain every item result.
+- `StochasticTask` runs a simulation with reproducible RNG streams. Each `StochasticInput<P>` combines a parameter value with a `repetition_index`; use `.with_repeated_input(param, repetitions)` for the common same-parameter batch case or `.with_repeated_inputs(params, repetitions)` for a lazy parameter-major sweep.
 - `DeterministicTask` runs a pure `input -> output` root computation.
 - `.transform(...)` builds a dependent deterministic analysis from an upstream task or transform.
 - `.stochastic_transform(...)` builds a dependent stochastic analysis from an upstream result.

--- a/crates/ssa-workflow/src/compute/deterministic.rs
+++ b/crates/ssa-workflow/src/compute/deterministic.rs
@@ -27,7 +27,9 @@ use crate::{
 ///     .function(|i: i32| Ok(i.abs()))
 ///     .cache(ManagedHashCache::<i32>::default())
 ///     .build()?;
-/// let results = task.with_inputs(0..10).collect()?;
+/// let results = task
+///     .with_inputs(0..10)
+///     .collect::<ssa_workflow::Result<Vec<_>>>()?;
 /// # Ok(())
 /// # }
 /// ```
@@ -170,13 +172,17 @@ mod tests {
 
         let n_inputs = 5;
 
-        let results1 = compute.with_inputs(0..n_inputs).collect()?;
+        let results1 = compute
+            .with_inputs(0..n_inputs)
+            .collect::<Result<Vec<_>>>()?;
 
         let expected: Vec<usize> = (0..n_inputs).map(|i| i * 3).collect();
         assert_eq!(results1, expected);
         assert_eq!(call_count.load(Ordering::SeqCst), n_inputs);
 
-        let results2 = compute.with_inputs(0..n_inputs).collect()?;
+        let results2 = compute
+            .with_inputs(0..n_inputs)
+            .collect::<Result<Vec<_>>>()?;
 
         assert_eq!(results2, expected);
         assert_eq!(call_count.load(Ordering::SeqCst), n_inputs);
@@ -214,7 +220,9 @@ mod tests {
             .build()?;
 
         let inputs = vec![3usize, 0, 2, 1, 4];
-        let results = compute.with_inputs(inputs.clone()).collect()?;
+        let results = compute
+            .with_inputs(inputs.clone())
+            .collect::<Result<Vec<_>>>()?;
 
         assert_eq!(
             results,
@@ -239,7 +247,10 @@ mod tests {
             .build()
             .expect("no-cache deterministic task should build");
 
-        let error = compute.with_inputs(0..128usize).collect().unwrap_err();
+        let error = compute
+            .with_inputs(0..128usize)
+            .collect::<Result<Vec<_>>>()
+            .unwrap_err();
 
         assert!(matches!(error, crate::Error::Compute(_)));
     }

--- a/crates/ssa-workflow/src/compute/execution.rs
+++ b/crates/ssa-workflow/src/compute/execution.rs
@@ -2,7 +2,9 @@
 
 use std::sync::{Arc, atomic};
 
-use rayon::prelude::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};
+use rayon::prelude::{
+    FromParallelIterator, IndexedParallelIterator, IntoParallelIterator, ParallelIterator,
+};
 
 use crate::{
     cache::CanonicalEncode,
@@ -70,10 +72,11 @@ pub trait Compute {
         unsafe { self.execute_one_with_buffer(input, &mut encode_buffer) }
     }
 
-    /// Start a batch execution builder for ordered `inputs`.
+    /// Start a batch execution plan for `inputs`.
     ///
-    /// Inputs must produce an [`IndexedParallelIterator`], so collected outputs follow the logical
-    /// input order and Rayon can use its indexed collection path.
+    /// Parallel collection requires an [`IndexedParallelIterator`], while serial collection
+    /// requires an [`IntoIterator`]. The corresponding bound is checked when the batch is
+    /// collected.
     ///
     /// Unordered parallel inputs such as `HashSet` intentionally do not satisfy this API:
     ///
@@ -85,7 +88,9 @@ pub trait Compute {
     ///     .function(|input: u8| Ok(input))
     ///     .build()?;
     /// let inputs = HashSet::from([1u8, 2u8]);
-    /// let _ = task.with_inputs(inputs);
+    /// let _ = task
+    ///     .with_inputs(inputs)
+    ///     .collect::<ssa_workflow::Result<Vec<_>>>();
     /// # Ok(())
     /// # }
     /// ```
@@ -97,8 +102,6 @@ pub trait Compute {
     fn with_inputs<I>(&self, inputs: I) -> BatchExecution<'_, Self, I>
     where
         Self: Sized,
-        I: IntoParallelIterator<Item = Self::Input>,
-        I::Iter: IndexedParallelIterator<Item = Self::Input>,
     {
         BatchExecution {
             compute: self,
@@ -108,12 +111,10 @@ pub trait Compute {
     }
 }
 
-/// Batch execution builder returned by [`Compute::with_inputs`].
+/// Batch execution plan returned by [`Compute::with_inputs`].
 pub struct BatchExecution<'a, C, I>
 where
     C: Compute,
-    I: IntoParallelIterator<Item = C::Input>,
-    I::Iter: IndexedParallelIterator<Item = C::Input>,
 {
     compute: &'a C,
     inputs: I,
@@ -123,8 +124,6 @@ where
 impl<'a, C, I> BatchExecution<'a, C, I>
 where
     C: Compute,
-    I: IntoParallelIterator<Item = C::Input>,
-    I::Iter: IndexedParallelIterator<Item = C::Input>,
 {
     /// Interrupt pending work when `signal` is set.
     ///
@@ -133,17 +132,20 @@ where
         self.interrupt_signal = Some(signal);
         self
     }
+}
 
-    /// Build the indexed parallel iterator for this batch.
+impl<'a, C, I> BatchExecution<'a, C, I>
+where
+    C: Clone + Compute + Sync + 'a,
+    I: IntoParallelIterator<Item = C::Input> + 'a,
+    I::Iter: IndexedParallelIterator<Item = C::Input>,
+    C::Output: Send,
+{
+    /// Convert this batch into its indexed parallel result iterator.
     ///
     /// Collecting this iterator as `Result<Vec<_>>` naturally short-circuits on errors.
     /// Collecting it as `Vec<Result<_>>` keeps successful and failed items.
-    pub fn execute(self) -> impl IndexedParallelIterator<Item = Result<C::Output>> + 'a
-    where
-        C: Clone + Sync + 'a,
-        I: 'a,
-        C::Output: Send,
-    {
+    pub fn into_par_iter(self) -> impl IndexedParallelIterator<Item = Result<C::Output>> + 'a {
         let signal = self.interrupt_signal;
         let compute = self.compute;
         self.inputs.into_par_iter().map_init(
@@ -161,28 +163,61 @@ where
         )
     }
 
-    /// Execute the batch and collect outputs in input order.
+    /// Execute the batch in the current Rayon pool and collect into `T` in input order.
     ///
-    /// This is the natural fail-fast collection mode: collection returns the first observed error.
-    pub fn collect(self) -> Result<Vec<C::Output>>
+    /// Collect as `Result<Vec<_>>` to short-circuit on errors, or as `Vec<Result<_>>` to retain
+    /// every item result.
+    pub fn collect<T>(self) -> T
     where
-        C: Clone + Sync + 'a,
-        I: 'a,
-        C::Output: Send,
+        T: FromParallelIterator<Result<C::Output>>,
     {
-        self.execute().collect()
+        self.into_par_iter().collect()
     }
 
-    /// Execute the batch and collect every item result.
+    /// Execute the batch in `pool` and collect into `T` in input order.
     ///
-    /// Use this for long sweeps where independent failures should not stop collection.
-    pub fn results(self) -> Vec<Result<C::Output>>
+    /// Collect as `Result<Vec<_>>` to short-circuit on errors, or as `Vec<Result<_>>` to retain
+    /// every item result.
+    pub fn collect_in<T>(self, pool: &rayon::ThreadPool) -> T
     where
-        C: Clone + Sync + 'a,
-        I: 'a,
-        C::Output: Send,
+        T: FromParallelIterator<Result<C::Output>> + Send,
     {
-        self.execute().collect()
+        let execution = self.into_par_iter();
+        pool.install(move || execution.collect())
+    }
+}
+
+impl<'a, C, I> BatchExecution<'a, C, I>
+where
+    C: Clone + Compute + 'a,
+    I: IntoIterator<Item = C::Input> + 'a,
+{
+    /// Execute the batch serially on the caller thread and collect into `T` in input order.
+    ///
+    /// Collect as `Result<Vec<_>>` to short-circuit on errors, or as `Vec<Result<_>>` to retain
+    /// every item result.
+    pub fn collect_serial<T>(self) -> T
+    where
+        T: FromIterator<Result<C::Output>>,
+    {
+        self.into_serial_iter().collect()
+    }
+
+    fn into_serial_iter(self) -> impl Iterator<Item = Result<C::Output>> + 'a {
+        let signal = self.interrupt_signal;
+        let mut compute = self.compute.clone();
+        let mut buffer = vec![0u8; C::Input::SIZE];
+
+        self.inputs.into_iter().map(move |input| {
+            if let Some(signal) = &signal
+                && signal.is_interrupted()
+            {
+                return Err(Error::Interrupted);
+            }
+
+            // Safety: The buffer is initialized with length Self::Input::SIZE.
+            unsafe { compute.execute_one_with_buffer(input, &mut buffer) }
+        })
     }
 }
 
@@ -213,7 +248,6 @@ impl InterruptSignal {
         self.interrupted.load(atomic::Ordering::Acquire)
     }
 }
-
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
@@ -302,15 +336,158 @@ mod tests {
             }
         }
 
-        #[test]
-        fn results_collects_every_item_result_without_outer_result() {
-            let results = FallibleCompute.with_inputs(0u8..4).results();
+        mod parallel {
+            use std::{ops::Range, rc::Rc};
 
-            assert_eq!(results.len(), 4);
-            assert_eq!(results[0].as_ref().ok(), Some(&10));
-            assert_eq!(results[1].as_ref().ok(), Some(&11));
-            assert!(matches!(results[2], Err(Error::Compute(_))));
-            assert_eq!(results[3].as_ref().ok(), Some(&13));
+            use super::*;
+
+            #[test]
+            fn collect_into_vec_preserves_item_results() {
+                let results = FallibleCompute
+                    .with_inputs(0u8..4)
+                    .collect::<Vec<Result<_>>>();
+
+                assert_eq!(results.len(), 4);
+                assert_eq!(results[0].as_ref().ok(), Some(&10));
+                assert_eq!(results[1].as_ref().ok(), Some(&11));
+                assert!(matches!(results[2], Err(Error::Compute(_))));
+                assert_eq!(results[3].as_ref().ok(), Some(&13));
+            }
+
+            #[derive(Clone)]
+            struct ThreadIndexCompute;
+
+            impl Compute for ThreadIndexCompute {
+                type Input = u8;
+                type Output = Option<usize>;
+
+                fn computation_path(&self) -> &ComputationPath {
+                    &TEST_PATH
+                }
+
+                fn execute_with_encoded_input(
+                    &mut self,
+                    _input: Self::Input,
+                    _encoded: &[u8],
+                ) -> Result<Self::Output> {
+                    Ok(rayon::current_thread_index())
+                }
+            }
+
+            #[test]
+            fn collect_in_uses_specified_pool() -> Result<()> {
+                let pool = rayon::ThreadPoolBuilder::new()
+                    .num_threads(1)
+                    .build()
+                    .expect("single-thread test pool should build");
+                let outputs = ThreadIndexCompute
+                    .with_inputs(0u8..8)
+                    .collect_in::<Result<Vec<_>>>(&pool)?;
+
+                assert_eq!(outputs, vec![Some(0); 8]);
+                Ok(())
+            }
+
+            struct LocalParallelInputs {
+                range: Range<u8>,
+                marker: Rc<()>,
+            }
+
+            impl IntoParallelIterator for LocalParallelInputs {
+                type Item = u8;
+                type Iter = <Range<u8> as IntoParallelIterator>::Iter;
+
+                fn into_par_iter(self) -> Self::Iter {
+                    drop(self.marker);
+                    self.range.into_par_iter()
+                }
+            }
+
+            #[test]
+            fn collect_in_accepts_local_sources_with_send_parallel_iterators() -> Result<()> {
+                let pool = rayon::ThreadPoolBuilder::new()
+                    .num_threads(1)
+                    .build()
+                    .expect("single-thread test pool should build");
+                let inputs = LocalParallelInputs {
+                    range: 0..2,
+                    marker: Rc::new(()),
+                };
+
+                let outputs = FallibleCompute
+                    .with_inputs(inputs)
+                    .collect_in::<Result<Vec<_>>>(&pool)?;
+
+                assert_eq!(outputs, [10, 11]);
+                Ok(())
+            }
+        }
+
+        mod serial {
+            use super::*;
+
+            #[test]
+            fn collect_into_result_preserves_order() -> Result<()> {
+                let outputs = FallibleCompute
+                    .with_inputs([3u8, 1, 0])
+                    .collect_serial::<Result<Vec<_>>>()?;
+
+                assert_eq!(outputs, [13, 11, 10]);
+                Ok(())
+            }
+
+            #[test]
+            fn collect_into_vec_preserves_order_and_item_results() {
+                let results = FallibleCompute
+                    .with_inputs(0u8..4)
+                    .collect_serial::<Vec<Result<_>>>();
+
+                assert_eq!(results.len(), 4);
+                assert_eq!(results[0].as_ref().ok(), Some(&10));
+                assert_eq!(results[1].as_ref().ok(), Some(&11));
+                assert!(matches!(results[2], Err(Error::Compute(_))));
+                assert_eq!(results[3].as_ref().ok(), Some(&13));
+            }
+
+            #[derive(Clone)]
+            struct CountingFallibleCompute {
+                calls: Arc<AtomicUsize>,
+            }
+
+            impl Compute for CountingFallibleCompute {
+                type Input = u8;
+                type Output = u8;
+
+                fn computation_path(&self) -> &ComputationPath {
+                    &TEST_PATH
+                }
+
+                fn execute_with_encoded_input(
+                    &mut self,
+                    input: Self::Input,
+                    _encoded: &[u8],
+                ) -> Result<Self::Output> {
+                    self.calls.fetch_add(1, Ordering::SeqCst);
+                    if input == 2 {
+                        Err(Error::Compute(Box::new(TestComputeError)))
+                    } else {
+                        Ok(input)
+                    }
+                }
+            }
+
+            #[test]
+            fn collect_into_result_stops_on_first_error() {
+                let calls = Arc::new(AtomicUsize::new(0));
+                let result = CountingFallibleCompute {
+                    calls: Arc::clone(&calls),
+                }
+                .with_inputs(0u8..5)
+                .collect_serial::<Result<Vec<_>>>();
+
+                assert!(matches!(result, Err(Error::Compute(_))));
+                assert_eq!(calls.load(Ordering::SeqCst), 3);
+            }
         }
     }
 
@@ -356,99 +533,127 @@ mod tests {
             }
         }
 
-        #[test]
-        fn signal_set_before_batch_skips_all_work() {
-            let signal = InterruptSignal::new();
-            signal.interrupt();
-            let calls = Arc::new(AtomicUsize::new(0));
+        mod parallel {
+            use super::*;
 
-            let results = CountingCompute {
-                calls: Arc::clone(&calls),
-            }
-            .with_inputs(0u8..4)
-            .with_interrupt_signal(signal)
-            .results();
+            #[test]
+            fn collect_into_vec_preserves_preset_interrupts() {
+                let signal = InterruptSignal::new();
+                signal.interrupt();
+                let calls = Arc::new(AtomicUsize::new(0));
 
-            assert_eq!(calls.load(Ordering::SeqCst), 0);
-            assert_eq!(results.len(), 4);
-            assert!(
-                results
-                    .iter()
-                    .all(|result| { matches!(result, Err(Error::Interrupted)) })
-            );
-        }
+                let results = CountingCompute {
+                    calls: Arc::clone(&calls),
+                }
+                .with_inputs(0u8..4)
+                .with_interrupt_signal(signal)
+                .collect::<Vec<Result<_>>>();
 
-        #[test]
-        fn collect_observes_preset_interrupt_signal() {
-            let signal = InterruptSignal::new();
-            signal.interrupt();
-            let calls = Arc::new(AtomicUsize::new(0));
-
-            let result = CountingCompute {
-                calls: Arc::clone(&calls),
-            }
-            .with_inputs(0u8..4)
-            .with_interrupt_signal(signal)
-            .collect();
-
-            assert!(matches!(result, Err(Error::Interrupted)));
-            assert_eq!(calls.load(Ordering::SeqCst), 0);
-        }
-
-        #[derive(Clone)]
-        struct InterruptingCompute {
-            signal: InterruptSignal,
-            calls: Arc<AtomicUsize>,
-        }
-
-        impl Compute for InterruptingCompute {
-            type Input = u8;
-            type Output = u8;
-
-            fn computation_path(&self) -> &ComputationPath {
-                &TEST_PATH
+                assert_eq!(calls.load(Ordering::SeqCst), 0);
+                assert_eq!(results.len(), 4);
+                assert!(
+                    results
+                        .iter()
+                        .all(|result| { matches!(result, Err(Error::Interrupted)) })
+                );
             }
 
-            fn execute_with_encoded_input(
-                &mut self,
-                input: Self::Input,
-                _encoded: &[u8],
-            ) -> Result<Self::Output> {
-                self.calls.fetch_add(1, Ordering::SeqCst);
-                self.signal.interrupt();
-                Ok(input)
+            #[test]
+            fn collect_into_result_observes_preset_interrupt() {
+                let signal = InterruptSignal::new();
+                signal.interrupt();
+                let calls = Arc::new(AtomicUsize::new(0));
+
+                let result = CountingCompute {
+                    calls: Arc::clone(&calls),
+                }
+                .with_inputs(0u8..4)
+                .with_interrupt_signal(signal)
+                .collect::<Result<Vec<_>>>();
+
+                assert!(matches!(result, Err(Error::Interrupted)));
+                assert_eq!(calls.load(Ordering::SeqCst), 0);
             }
-        }
 
-        #[test]
-        fn signal_set_during_batch_skips_pending_work() {
-            let signal = InterruptSignal::new();
-            let calls = Arc::new(AtomicUsize::new(0));
-            let compute = InterruptingCompute {
-                signal: signal.clone(),
-                calls: Arc::clone(&calls),
-            };
+            #[derive(Clone)]
+            struct InterruptingCompute {
+                signal: InterruptSignal,
+                calls: Arc<AtomicUsize>,
+            }
 
-            let pool = rayon::ThreadPoolBuilder::new()
-                .num_threads(1)
-                .build()
-                .expect("single-thread test pool should build");
-            let results = pool.install(|| {
-                compute
+            impl Compute for InterruptingCompute {
+                type Input = u8;
+                type Output = u8;
+
+                fn computation_path(&self) -> &ComputationPath {
+                    &TEST_PATH
+                }
+
+                fn execute_with_encoded_input(
+                    &mut self,
+                    input: Self::Input,
+                    _encoded: &[u8],
+                ) -> Result<Self::Output> {
+                    self.calls.fetch_add(1, Ordering::SeqCst);
+                    self.signal.interrupt();
+                    Ok(input)
+                }
+            }
+
+            #[test]
+            fn collect_in_skips_pending_work_after_interrupt() {
+                let signal = InterruptSignal::new();
+                let calls = Arc::new(AtomicUsize::new(0));
+                let compute = InterruptingCompute {
+                    signal: signal.clone(),
+                    calls: Arc::clone(&calls),
+                };
+
+                let pool = rayon::ThreadPoolBuilder::new()
+                    .num_threads(1)
+                    .build()
+                    .expect("single-thread test pool should build");
+                let results = compute
                     .with_inputs(0u8..4)
                     .with_interrupt_signal(signal)
-                    .results()
-            });
+                    .collect_in::<Vec<Result<_>>>(&pool);
 
-            assert_eq!(calls.load(Ordering::SeqCst), 1);
-            assert_eq!(results.iter().filter(|result| result.is_ok()).count(), 1);
-            assert_eq!(
-                results
-                    .iter()
-                    .filter(|result| matches!(result, Err(Error::Interrupted)))
-                    .count(),
-                3
-            );
+                assert_eq!(calls.load(Ordering::SeqCst), 1);
+                assert_eq!(results.iter().filter(|result| result.is_ok()).count(), 1);
+                assert_eq!(
+                    results
+                        .iter()
+                        .filter(|result| matches!(result, Err(Error::Interrupted)))
+                        .count(),
+                    3
+                );
+            }
+        }
+
+        mod serial {
+            use super::*;
+
+            #[test]
+            fn collect_into_vec_preserves_preset_interrupts() {
+                let signal = InterruptSignal::new();
+                signal.interrupt();
+                let calls = Arc::new(AtomicUsize::new(0));
+
+                let results = CountingCompute {
+                    calls: Arc::clone(&calls),
+                }
+                .with_inputs(0u8..4)
+                .with_interrupt_signal(signal)
+                .collect_serial::<Vec<Result<_>>>();
+
+                assert_eq!(calls.load(Ordering::SeqCst), 0);
+                assert_eq!(results.len(), 4);
+                assert!(
+                    results
+                        .iter()
+                        .all(|result| matches!(result, Err(Error::Interrupted)))
+                );
+            }
         }
     }
 }

--- a/crates/ssa-workflow/src/compute/execution.rs
+++ b/crates/ssa-workflow/src/compute/execution.rs
@@ -1,4 +1,4 @@
-//! Core execution traits and batch execution builders.
+//! Core execution traits and batch execution.
 
 use std::sync::{Arc, atomic};
 
@@ -64,21 +64,20 @@ pub trait Compute {
     ///
     /// This is the safe, single-item counterpart to [`Self::execute_one_with_buffer`].
     ///
-    /// If you need to execute multiple ordered inputs in parallel, use [`Self::with_inputs`]
-    /// instead.
+    /// If you need to execute multiple inputs, use [`Self::with_inputs`] instead.
     fn execute_one(&mut self, input: Self::Input) -> Result<Self::Output> {
         let mut encode_buffer = vec![0u8; Self::Input::SIZE];
         // Safety: The buffer is initialized with length Self::Input::SIZE.
         unsafe { self.execute_one_with_buffer(input, &mut encode_buffer) }
     }
 
-    /// Start a batch execution plan for `inputs`.
+    /// Create a batch execution for `inputs`.
     ///
     /// Parallel collection requires an [`IndexedParallelIterator`], while serial collection
-    /// requires an [`IntoIterator`]. The corresponding bound is checked when the batch is
-    /// collected.
+    /// requires an [`IntoIterator`]. The selected execution method determines which input bounds
+    /// are required.
     ///
-    /// Unordered parallel inputs such as `HashSet` intentionally do not satisfy this API:
+    /// Unordered parallel inputs such as `HashSet` do not support parallel collection:
     ///
     /// ```compile_fail
     /// # use ssa_workflow::prelude::*;
@@ -111,7 +110,7 @@ pub trait Compute {
     }
 }
 
-/// Batch execution plan returned by [`Compute::with_inputs`].
+/// Lazy batch execution returned by [`Compute::with_inputs`].
 pub struct BatchExecution<'a, C, I>
 where
     C: Compute,
@@ -163,7 +162,10 @@ where
         )
     }
 
-    /// Execute the batch in the current Rayon pool and collect into `T` in input order.
+    /// Execute the batch in the current Rayon pool and collect into `T`.
+    ///
+    /// Outside a Rayon pool, execution uses the global pool. The result iterator follows input
+    /// order; ordered targets such as `Vec` preserve that order.
     ///
     /// Collect as `Result<Vec<_>>` to short-circuit on errors, or as `Vec<Result<_>>` to retain
     /// every item result.
@@ -174,7 +176,9 @@ where
         self.into_par_iter().collect()
     }
 
-    /// Execute the batch in `pool` and collect into `T` in input order.
+    /// Execute the batch in `pool` and collect into `T`.
+    ///
+    /// The result iterator follows input order; ordered targets such as `Vec` preserve that order.
     ///
     /// Collect as `Result<Vec<_>>` to short-circuit on errors, or as `Vec<Result<_>>` to retain
     /// every item result.
@@ -192,7 +196,9 @@ where
     C: Clone + Compute + 'a,
     I: IntoIterator<Item = C::Input> + 'a,
 {
-    /// Execute the batch serially on the caller thread and collect into `T` in input order.
+    /// Execute the batch serially on the caller thread and collect into `T`.
+    ///
+    /// Results are produced in input order; ordered targets such as `Vec` preserve that order.
     ///
     /// Collect as `Result<Vec<_>>` to short-circuit on errors, or as `Vec<Result<_>>` to retain
     /// every item result.

--- a/crates/ssa-workflow/src/compute/mod.rs
+++ b/crates/ssa-workflow/src/compute/mod.rs
@@ -8,7 +8,9 @@ pub mod transform;
 
 pub use deterministic::DeterministicTask;
 pub use execution::{BatchExecution, Compute, InterruptSignal};
-pub use stochastic::{StochasticComputeExt, StochasticInput, StochasticTask};
+pub use stochastic::{
+    RepeatedStochasticInputs, StochasticComputeExt, StochasticInput, StochasticTask,
+};
 pub use stream::{
     MultiStreams, RandomVariable, RngBundle, SeedSource, SingleStream, StreamSeed, StreamSeeds,
 };

--- a/crates/ssa-workflow/src/compute/stochastic/input.rs
+++ b/crates/ssa-workflow/src/compute/stochastic/input.rs
@@ -1,0 +1,995 @@
+//! Stochastic input identity and lazy repeated input sources.
+
+use std::ops::Range;
+
+use rayon::{
+    iter::plumbing::{Consumer, Producer, ProducerCallback, UnindexedConsumer, bridge},
+    prelude::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator},
+};
+
+use crate::cache::CanonicalEncode;
+
+/// Input for one stochastic execution.
+///
+/// This wraps a deterministic parameter value (`param`) with a `repetition_index`.
+///
+/// The pair serves two roles:
+///
+/// - It is the canonical input used for cache-key construction.
+/// - It selects one reproducible stochastic repetition.
+///
+/// # Encoding
+///
+/// Canonical encoding is `param` bytes followed by big-endian `repetition_index` bytes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StochasticInput<P> {
+    /// Deterministic model/config input.
+    pub param: P,
+    /// Repetition index used for random stream derivation.
+    pub repetition_index: u64,
+}
+
+impl<P> StochasticInput<P> {
+    /// Create a stochastic input from `(param, repetition_index)`.
+    pub const fn new(param: P, repetition_index: u64) -> Self {
+        Self {
+            param,
+            repetition_index,
+        }
+    }
+}
+
+impl<P> From<(P, u64)> for StochasticInput<P> {
+    fn from((param, repetition_index): (P, u64)) -> Self {
+        Self {
+            param,
+            repetition_index,
+        }
+    }
+}
+
+impl<P: CanonicalEncode> CanonicalEncode for StochasticInput<P> {
+    const SIZE: usize = P::SIZE + u64::SIZE;
+
+    unsafe fn encode_into(&self, buffer: &mut [u8]) {
+        unsafe {
+            self.param.encode_into(&mut buffer[..P::SIZE]);
+            self.repetition_index
+                .encode_into(&mut buffer[P::SIZE..Self::SIZE]);
+        }
+    }
+}
+
+/// Lazy ordered input source for repeated stochastic executions.
+///
+/// This source represents the logical Cartesian product of `params` and
+/// `0..repetitions` without materializing every [`StochasticInput`]. Items are emitted in
+/// parameter-major order: all repetitions for `params[0]`, then all repetitions for `params[1]`,
+/// and so on.
+///
+/// Converting the source into an indexed parallel iterator panics if the total number of repeated
+/// inputs cannot be represented by `usize`.
+#[derive(Debug, Clone)]
+pub struct RepeatedStochasticInputs<I> {
+    params: I,
+    repetitions: usize,
+}
+
+impl<I> RepeatedStochasticInputs<I> {
+    /// Create a lazy repeated stochastic input source.
+    pub const fn new(params: I, repetitions: usize) -> Self {
+        Self {
+            params,
+            repetitions,
+        }
+    }
+}
+
+impl<I> IntoIterator for RepeatedStochasticInputs<I>
+where
+    I: IntoIterator,
+    I::Item: Clone,
+{
+    type IntoIter = RepeatedStochasticIntoIter<I::IntoIter>;
+    type Item = StochasticInput<I::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        RepeatedStochasticIntoIter {
+            params: self.params.into_iter(),
+            current_param: None,
+            repetitions: self.repetitions,
+            repetition_index: 0,
+        }
+    }
+}
+
+/// Serial iterator over a [`RepeatedStochasticInputs`] source.
+#[derive(Debug, Clone)]
+pub struct RepeatedStochasticIntoIter<I>
+where
+    I: Iterator,
+{
+    params: I,
+    current_param: Option<I::Item>,
+    repetitions: usize,
+    repetition_index: usize,
+}
+
+impl<I> Iterator for RepeatedStochasticIntoIter<I>
+where
+    I: Iterator,
+    I::Item: Clone,
+{
+    type Item = StochasticInput<I::Item>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.repetitions == 0 {
+            return None;
+        }
+
+        if self.current_param.is_none() {
+            self.current_param = self.params.next();
+            self.repetition_index = 0;
+        }
+
+        let param = self.current_param.as_ref()?.clone();
+        let repetition_index = self.repetition_index;
+        self.repetition_index += 1;
+
+        if self.repetition_index == self.repetitions {
+            self.current_param = None;
+        }
+
+        Some(StochasticInput::new(param, repetition_index as u64))
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        if self.repetitions == 0 {
+            return (0, Some(0));
+        }
+
+        let current_remaining = self
+            .current_param
+            .as_ref()
+            .map_or(0, |_| self.repetitions - self.repetition_index);
+        let (lower, upper) = self.params.size_hint();
+        let lower = lower
+            .saturating_mul(self.repetitions)
+            .saturating_add(current_remaining);
+        let upper = upper
+            .and_then(|value| value.checked_mul(self.repetitions))
+            .and_then(|value| value.checked_add(current_remaining));
+        (lower, upper)
+    }
+}
+
+impl<I> IntoParallelIterator for RepeatedStochasticInputs<I>
+where
+    I: IntoParallelIterator,
+    I::Item: Clone + Send,
+    I::Iter: IndexedParallelIterator,
+{
+    type Item = StochasticInput<I::Item>;
+    type Iter = RepeatedStochasticIntoParIter<I::Iter>;
+
+    fn into_par_iter(self) -> Self::Iter {
+        let params = self.params.into_par_iter();
+        let parameter_count = params.len();
+        let Some(len) = parameter_count.checked_mul(self.repetitions) else {
+            panic!(
+                "repeated stochastic input count overflow: {parameter_count} parameters with {} repetitions",
+                self.repetitions,
+            );
+        };
+
+        RepeatedStochasticIntoParIter {
+            params,
+            repetitions: self.repetitions,
+            len,
+        }
+    }
+}
+
+/// Indexed parallel iterator over a [`RepeatedStochasticInputs`] source.
+#[derive(Debug, Clone)]
+pub struct RepeatedStochasticIntoParIter<I> {
+    params: I,
+    repetitions: usize,
+    len: usize,
+}
+
+impl<I> ParallelIterator for RepeatedStochasticIntoParIter<I>
+where
+    I: IndexedParallelIterator,
+    I::Item: Clone,
+{
+    type Item = StochasticInput<I::Item>;
+
+    fn drive_unindexed<C>(self, consumer: C) -> C::Result
+    where
+        C: UnindexedConsumer<Self::Item>,
+    {
+        bridge(self, consumer)
+    }
+
+    fn opt_len(&self) -> Option<usize> {
+        Some(self.len)
+    }
+}
+
+impl<I> IndexedParallelIterator for RepeatedStochasticIntoParIter<I>
+where
+    I: IndexedParallelIterator,
+    I::Item: Clone,
+{
+    fn len(&self) -> usize {
+        self.len
+    }
+
+    fn drive<C>(self, consumer: C) -> C::Result
+    where
+        C: Consumer<Self::Item>,
+    {
+        bridge(self, consumer)
+    }
+
+    fn with_producer<CB>(self, callback: CB) -> CB::Output
+    where
+        CB: ProducerCallback<Self::Item>,
+    {
+        let parameter_count = self.params.len();
+        self.params.with_producer(RepeatedStochasticCallback {
+            callback,
+            parameter_count,
+            repetitions: self.repetitions,
+        })
+    }
+}
+
+struct RepeatedStochasticCallback<CB> {
+    callback: CB,
+    parameter_count: usize,
+    repetitions: usize,
+}
+
+impl<P, CB> ProducerCallback<P> for RepeatedStochasticCallback<CB>
+where
+    P: Clone + Send,
+    CB: ProducerCallback<StochasticInput<P>>,
+{
+    type Output = CB::Output;
+
+    fn callback<B>(self, base: B) -> Self::Output
+    where
+        B: Producer<Item = P>,
+    {
+        self.callback.callback(RepeatedStochasticProducer {
+            base,
+            parameter_count: self.parameter_count,
+            repetitions: self.repetitions,
+            prefix: None,
+            suffix: None,
+        })
+    }
+}
+
+struct RepeatedStochasticProducer<B>
+where
+    B: Producer,
+{
+    base: B,
+    parameter_count: usize,
+    repetitions: usize,
+    prefix: Option<RepeatedParameter<B::Item>>,
+    suffix: Option<RepeatedParameter<B::Item>>,
+}
+
+impl<B> RepeatedStochasticProducer<B>
+where
+    B: Producer,
+    B::Item: Clone,
+{
+    fn len(&self) -> usize {
+        self.prefix.as_ref().map_or(0, RepeatedParameter::len)
+            + self.parameter_count * self.repetitions
+            + self.suffix.as_ref().map_or(0, RepeatedParameter::len)
+    }
+
+    fn split_zero_repetitions(self) -> (Self, Self) {
+        debug_assert_eq!(self.len(), 0);
+        let (left, right) = self.base.split_at(0);
+        (
+            Self {
+                base: left,
+                parameter_count: 0,
+                repetitions: 0,
+                prefix: None,
+                suffix: None,
+            },
+            Self {
+                base: right,
+                parameter_count: self.parameter_count,
+                repetitions: 0,
+                prefix: None,
+                suffix: None,
+            },
+        )
+    }
+}
+
+impl<B> Producer for RepeatedStochasticProducer<B>
+where
+    B: Producer,
+    B::Item: Clone + Send,
+{
+    type IntoIter = RepeatedStochasticProducerIter<B::IntoIter>;
+    type Item = StochasticInput<B::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        RepeatedStochasticProducerIter {
+            prefix: self.prefix,
+            front: None,
+            base: self.base.into_iter(),
+            back: None,
+            suffix: self.suffix,
+            repetitions: self.repetitions,
+        }
+    }
+
+    fn split_at(self, index: usize) -> (Self, Self) {
+        assert!(index <= self.len());
+        if self.repetitions == 0 {
+            assert_eq!(index, 0);
+            return self.split_zero_repetitions();
+        }
+
+        let prefix_len = self.prefix.as_ref().map_or(0, RepeatedParameter::len);
+        if index < prefix_len {
+            let (left_prefix, right_prefix) = self
+                .prefix
+                .expect("prefix length is non-zero")
+                .split_at(index);
+            let (left_base, right_base) = self.base.split_at(0);
+            return (
+                Self {
+                    base: left_base,
+                    parameter_count: 0,
+                    repetitions: self.repetitions,
+                    prefix: left_prefix,
+                    suffix: None,
+                },
+                Self {
+                    base: right_base,
+                    parameter_count: self.parameter_count,
+                    repetitions: self.repetitions,
+                    prefix: right_prefix,
+                    suffix: self.suffix,
+                },
+            );
+        }
+
+        let base_index = index - prefix_len;
+        let base_len = self.parameter_count * self.repetitions;
+        if base_index <= base_len {
+            let parameter_index = base_index / self.repetitions;
+            let repetition_index = base_index % self.repetitions;
+            let (left_base, right_base) = self.base.split_at(parameter_index);
+
+            if repetition_index == 0 {
+                return (
+                    Self {
+                        base: left_base,
+                        parameter_count: parameter_index,
+                        repetitions: self.repetitions,
+                        prefix: self.prefix,
+                        suffix: None,
+                    },
+                    Self {
+                        base: right_base,
+                        parameter_count: self.parameter_count - parameter_index,
+                        repetitions: self.repetitions,
+                        prefix: None,
+                        suffix: self.suffix,
+                    },
+                );
+            }
+
+            let (boundary, right_base) = right_base.split_at(1);
+            let mut boundary = boundary.into_iter();
+            let parameter = boundary
+                .next()
+                .expect("a producer split at one must contain one parameter");
+            debug_assert!(boundary.next().is_none());
+            let (left_suffix, right_prefix) =
+                RepeatedParameter::new(parameter, 0..self.repetitions).split_at(repetition_index);
+
+            return (
+                Self {
+                    base: left_base,
+                    parameter_count: parameter_index,
+                    repetitions: self.repetitions,
+                    prefix: self.prefix,
+                    suffix: left_suffix,
+                },
+                Self {
+                    base: right_base,
+                    parameter_count: self.parameter_count - parameter_index - 1,
+                    repetitions: self.repetitions,
+                    prefix: right_prefix,
+                    suffix: self.suffix,
+                },
+            );
+        }
+
+        let suffix_index = base_index - base_len;
+        let (left_suffix, right_prefix) = self
+            .suffix
+            .expect("the split index lies within the suffix")
+            .split_at(suffix_index);
+        let (left_base, right_base) = self.base.split_at(self.parameter_count);
+
+        (
+            Self {
+                base: left_base,
+                parameter_count: self.parameter_count,
+                repetitions: self.repetitions,
+                prefix: self.prefix,
+                suffix: left_suffix,
+            },
+            Self {
+                base: right_base,
+                parameter_count: 0,
+                repetitions: self.repetitions,
+                prefix: right_prefix,
+                suffix: None,
+            },
+        )
+    }
+}
+
+#[derive(Debug, Clone)]
+struct RepeatedParameter<P> {
+    parameter: P,
+    range: Range<usize>,
+}
+
+impl<P> RepeatedParameter<P>
+where
+    P: Clone,
+{
+    fn new(parameter: P, range: Range<usize>) -> Self {
+        Self { parameter, range }
+    }
+
+    fn len(&self) -> usize {
+        self.range.len()
+    }
+
+    fn split_at(self, index: usize) -> (Option<Self>, Option<Self>) {
+        assert!(index <= self.len());
+        if index == 0 {
+            return (None, Some(self));
+        }
+        if index == self.len() {
+            return (Some(self), None);
+        }
+
+        let middle = self.range.start + index;
+        let right_parameter = self.parameter.clone();
+        (
+            Some(Self::new(self.parameter, self.range.start..middle)),
+            Some(Self::new(right_parameter, middle..self.range.end)),
+        )
+    }
+}
+
+impl<P> Iterator for RepeatedParameter<P>
+where
+    P: Clone,
+{
+    type Item = StochasticInput<P>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.range.next().map(|repetition_index| {
+            StochasticInput::new(self.parameter.clone(), repetition_index as u64)
+        })
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.range.size_hint()
+    }
+}
+
+impl<P> DoubleEndedIterator for RepeatedParameter<P>
+where
+    P: Clone,
+{
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.range.next_back().map(|repetition_index| {
+            StochasticInput::new(self.parameter.clone(), repetition_index as u64)
+        })
+    }
+}
+
+impl<P> ExactSizeIterator for RepeatedParameter<P> where P: Clone {}
+
+struct RepeatedStochasticProducerIter<I>
+where
+    I: Iterator,
+{
+    prefix: Option<RepeatedParameter<I::Item>>,
+    front: Option<RepeatedParameter<I::Item>>,
+    base: I,
+    back: Option<RepeatedParameter<I::Item>>,
+    suffix: Option<RepeatedParameter<I::Item>>,
+    repetitions: usize,
+}
+
+impl<I> RepeatedStochasticProducerIter<I>
+where
+    I: Iterator,
+    I::Item: Clone,
+{
+    fn next_from(
+        segment: &mut Option<RepeatedParameter<I::Item>>,
+    ) -> Option<StochasticInput<I::Item>> {
+        let item = segment.as_mut()?.next();
+        if segment.as_ref().is_some_and(|segment| segment.len() == 0) {
+            *segment = None;
+        }
+        item
+    }
+
+    fn next_back_from(
+        segment: &mut Option<RepeatedParameter<I::Item>>,
+    ) -> Option<StochasticInput<I::Item>> {
+        let item = segment.as_mut()?.next_back();
+        if segment.as_ref().is_some_and(|segment| segment.len() == 0) {
+            *segment = None;
+        }
+        item
+    }
+}
+
+impl<I> Iterator for RepeatedStochasticProducerIter<I>
+where
+    I: DoubleEndedIterator + ExactSizeIterator,
+    I::Item: Clone,
+{
+    type Item = StochasticInput<I::Item>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.repetitions == 0 {
+            return None;
+        }
+        if let Some(item) = Self::next_from(&mut self.prefix) {
+            return Some(item);
+        }
+        if let Some(item) = Self::next_from(&mut self.front) {
+            return Some(item);
+        }
+        if let Some(parameter) = self.base.next() {
+            self.front = Some(RepeatedParameter::new(parameter, 0..self.repetitions));
+            return Self::next_from(&mut self.front);
+        }
+        if let Some(item) = Self::next_from(&mut self.back) {
+            return Some(item);
+        }
+        Self::next_from(&mut self.suffix)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.len();
+        (len, Some(len))
+    }
+}
+
+impl<I> DoubleEndedIterator for RepeatedStochasticProducerIter<I>
+where
+    I: DoubleEndedIterator + ExactSizeIterator,
+    I::Item: Clone,
+{
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.repetitions == 0 {
+            return None;
+        }
+        if let Some(item) = Self::next_back_from(&mut self.suffix) {
+            return Some(item);
+        }
+        if let Some(item) = Self::next_back_from(&mut self.back) {
+            return Some(item);
+        }
+        if let Some(parameter) = self.base.next_back() {
+            self.back = Some(RepeatedParameter::new(parameter, 0..self.repetitions));
+            return Self::next_back_from(&mut self.back);
+        }
+        if let Some(item) = Self::next_back_from(&mut self.front) {
+            return Some(item);
+        }
+        Self::next_back_from(&mut self.prefix)
+    }
+}
+
+impl<I> ExactSizeIterator for RepeatedStochasticProducerIter<I>
+where
+    I: DoubleEndedIterator + ExactSizeIterator,
+    I::Item: Clone,
+{
+    fn len(&self) -> usize {
+        self.prefix.as_ref().map_or(0, RepeatedParameter::len)
+            + self.front.as_ref().map_or(0, RepeatedParameter::len)
+            + self.base.len() * self.repetitions
+            + self.back.as_ref().map_or(0, RepeatedParameter::len)
+            + self.suffix.as_ref().map_or(0, RepeatedParameter::len)
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    use super::*;
+
+    struct DualModeInputs {
+        values: Range<u32>,
+        serial_conversions: Arc<AtomicUsize>,
+        parallel_conversions: Arc<AtomicUsize>,
+    }
+
+    impl IntoIterator for DualModeInputs {
+        type IntoIter = Range<u32>;
+        type Item = u32;
+
+        fn into_iter(self) -> Self::IntoIter {
+            self.serial_conversions.fetch_add(1, Ordering::SeqCst);
+            self.values
+        }
+    }
+
+    impl IntoParallelIterator for DualModeInputs {
+        type Item = u32;
+        type Iter = <Range<u32> as IntoParallelIterator>::Iter;
+
+        fn into_par_iter(self) -> Self::Iter {
+            self.parallel_conversions.fetch_add(1, Ordering::SeqCst);
+            self.values.into_par_iter()
+        }
+    }
+
+    enum SplitPattern {
+        Prefix,
+        Suffix,
+    }
+
+    struct CollectSplitPattern(SplitPattern);
+
+    impl ProducerCallback<StochasticInput<u32>> for CollectSplitPattern {
+        type Output = Vec<StochasticInput<u32>>;
+
+        fn callback<P>(self, producer: P) -> Self::Output
+        where
+            P: Producer<Item = StochasticInput<u32>>,
+        {
+            let (first, second, third) = match self.0 {
+                SplitPattern::Prefix => {
+                    let (first, remainder) = producer.split_at(1);
+                    let (second, third) = remainder.split_at(1);
+                    (first, second, third)
+                }
+                SplitPattern::Suffix => {
+                    let (remainder, third) = producer.split_at(5);
+                    let (first, second) = remainder.split_at(4);
+                    (first, second, third)
+                }
+            };
+
+            first
+                .into_iter()
+                .chain(second.into_iter())
+                .chain(third.into_iter())
+                .collect()
+        }
+    }
+
+    struct CollectMixedEnds;
+
+    impl ProducerCallback<StochasticInput<u32>> for CollectMixedEnds {
+        type Output = Vec<StochasticInput<u32>>;
+
+        fn callback<P>(self, producer: P) -> Self::Output
+        where
+            P: Producer<Item = StochasticInput<u32>>,
+        {
+            let mut iter = producer.into_iter();
+            assert_eq!(iter.size_hint(), (6, Some(6)));
+            let actual = vec![
+                iter.next().expect("the producer has a front item"),
+                iter.next_back().expect("the producer has a back item"),
+                iter.next().expect("the front parameter has another repeat"),
+                iter.next_back()
+                    .expect("the back parameter has another repeat"),
+                iter.next().expect("the front parameter has a final repeat"),
+                iter.next_back()
+                    .expect("the back parameter has a final repeat"),
+            ];
+            assert_eq!(iter.size_hint(), (0, Some(0)));
+            assert_eq!(iter.next(), None);
+            actual
+        }
+    }
+
+    enum CrossedEnd {
+        Front,
+        Back,
+    }
+
+    struct CollectCrossedEnd(CrossedEnd);
+
+    impl ProducerCallback<StochasticInput<u32>> for CollectCrossedEnd {
+        type Output = Vec<StochasticInput<u32>>;
+
+        fn callback<P>(self, producer: P) -> Self::Output
+        where
+            P: Producer<Item = StochasticInput<u32>>,
+        {
+            let mut iter = producer.into_iter();
+            match self.0 {
+                CrossedEnd::Front => vec![
+                    iter.next().expect("the producer has a front item"),
+                    iter.next_back().expect("the producer has a back item"),
+                    iter.next_back()
+                        .expect("the back parameter has another repeat"),
+                    iter.next_back()
+                        .expect("the back parameter has a final repeat"),
+                    iter.next_back()
+                        .expect("the front parameter remains available from the back"),
+                    iter.next_back()
+                        .expect("the front parameter has one remaining repeat"),
+                ],
+                CrossedEnd::Back => vec![
+                    iter.next_back().expect("the producer has a back item"),
+                    iter.next().expect("the producer has a front item"),
+                    iter.next().expect("the front parameter has another repeat"),
+                    iter.next().expect("the front parameter has a final repeat"),
+                    iter.next()
+                        .expect("the back parameter remains available from the front"),
+                    iter.next()
+                        .expect("the back parameter has one remaining repeat"),
+                ],
+            }
+        }
+    }
+
+    struct SplitEmpty;
+
+    impl ProducerCallback<StochasticInput<u32>> for SplitEmpty {
+        type Output = (usize, usize);
+
+        fn callback<P>(self, producer: P) -> Self::Output
+        where
+            P: Producer<Item = StochasticInput<u32>>,
+        {
+            let (left, right) = producer.split_at(0);
+            let mut left = left.into_iter();
+            let mut right = right.into_iter();
+            assert_eq!(left.next_back(), None);
+            assert_eq!(right.next_back(), None);
+            (left.len(), right.len())
+        }
+    }
+
+    #[test]
+    fn stochastic_input_constructors_encode_identically() {
+        let from_new = StochasticInput::new(123u64, 9);
+        let from_tuple: StochasticInput<u64> = (123u64, 9u64).into();
+        let from_fields = StochasticInput {
+            param: 123u64,
+            repetition_index: 9,
+        };
+
+        let mut buffer_new = vec![0u8; StochasticInput::<u64>::SIZE];
+        let mut buffer_tuple = vec![0u8; StochasticInput::<u64>::SIZE];
+        let mut buffer_fields = vec![0u8; StochasticInput::<u64>::SIZE];
+
+        let encoded_new = unsafe { from_new.encode_with_buffer(&mut buffer_new) };
+        let encoded_tuple = unsafe { from_tuple.encode_with_buffer(&mut buffer_tuple) };
+        let encoded_fields = unsafe { from_fields.encode_with_buffer(&mut buffer_fields) };
+
+        assert_eq!(encoded_new, encoded_tuple);
+        assert_eq!(encoded_new, encoded_fields);
+    }
+
+    #[test]
+    fn repeated_inputs_support_standard_serial_and_parallel_iteration() {
+        let inputs = RepeatedStochasticInputs::new(10u32..12, 2);
+        let expected = vec![
+            StochasticInput::new(10, 0),
+            StochasticInput::new(10, 1),
+            StochasticInput::new(11, 0),
+            StochasticInput::new(11, 1),
+        ];
+        let expected_len = expected.len();
+
+        assert_eq!(inputs.clone().into_iter().collect::<Vec<_>>(), expected);
+
+        let parallel_inputs = inputs.clone().into_par_iter();
+        assert_eq!(parallel_inputs.opt_len(), Some(expected_len));
+        assert_eq!(parallel_inputs.len(), expected_len);
+
+        let mut parallel_outputs = Vec::new();
+        parallel_inputs.collect_into_vec(&mut parallel_outputs);
+        assert_eq!(parallel_outputs, expected);
+
+        let indexed_outputs = inputs
+            .into_par_iter()
+            .zip(0..expected_len)
+            .collect::<Vec<_>>();
+        let expected_indexed = expected
+            .into_iter()
+            .zip(0..expected_len)
+            .collect::<Vec<_>>();
+        assert_eq!(indexed_outputs, expected_indexed);
+    }
+
+    #[test]
+    fn repeated_inputs_use_the_selected_source_mode_directly() {
+        let serial_conversions = Arc::new(AtomicUsize::new(0));
+        let parallel_conversions = Arc::new(AtomicUsize::new(0));
+        let inputs = DualModeInputs {
+            values: 10..12,
+            serial_conversions: Arc::clone(&serial_conversions),
+            parallel_conversions: Arc::clone(&parallel_conversions),
+        };
+        let serial = RepeatedStochasticInputs::new(inputs, 2)
+            .into_iter()
+            .collect::<Vec<_>>();
+
+        assert_eq!(serial.len(), 4);
+        assert_eq!(serial_conversions.load(Ordering::SeqCst), 1);
+        assert_eq!(parallel_conversions.load(Ordering::SeqCst), 0);
+
+        let inputs = DualModeInputs {
+            values: 10..12,
+            serial_conversions: Arc::clone(&serial_conversions),
+            parallel_conversions: Arc::clone(&parallel_conversions),
+        };
+        let parallel = RepeatedStochasticInputs::new(inputs, 2)
+            .into_par_iter()
+            .collect::<Vec<_>>();
+
+        assert_eq!(parallel.len(), 4);
+        assert_eq!(serial_conversions.load(Ordering::SeqCst), 1);
+        assert_eq!(parallel_conversions.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn repeated_parallel_producer_splits_at_every_output_boundary() {
+        let params = [10u32, 20];
+        let expected = vec![
+            StochasticInput::new(10, 0),
+            StochasticInput::new(10, 1),
+            StochasticInput::new(10, 2),
+            StochasticInput::new(20, 0),
+            StochasticInput::new(20, 1),
+            StochasticInput::new(20, 2),
+        ];
+
+        for split_index in 0..=expected.len() {
+            let left = RepeatedStochasticInputs::new(params, 3)
+                .into_par_iter()
+                .take(split_index)
+                .collect::<Vec<_>>();
+            let right = RepeatedStochasticInputs::new(params, 3)
+                .into_par_iter()
+                .skip(split_index)
+                .collect::<Vec<_>>();
+            let actual = left.into_iter().chain(right).collect::<Vec<_>>();
+
+            assert_eq!(actual, expected, "split index {split_index}");
+        }
+
+        let reversed = RepeatedStochasticInputs::new(params, 3)
+            .into_par_iter()
+            .rev()
+            .collect::<Vec<_>>();
+        assert_eq!(reversed, expected.into_iter().rev().collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn repeated_parallel_producer_supports_recursive_boundary_splits() {
+        let expected = RepeatedStochasticInputs::new([10u32, 20], 3)
+            .into_iter()
+            .collect::<Vec<_>>();
+        let prefix_split = RepeatedStochasticInputs::new([10u32, 20], 3)
+            .into_par_iter()
+            .with_producer(CollectSplitPattern(SplitPattern::Prefix));
+        let suffix_split = RepeatedStochasticInputs::new([10u32, 20], 3)
+            .into_par_iter()
+            .with_producer(CollectSplitPattern(SplitPattern::Suffix));
+
+        assert_eq!(prefix_split, expected);
+        assert_eq!(suffix_split, expected);
+    }
+
+    #[test]
+    fn repeated_parallel_producer_supports_mixed_double_ended_iteration() {
+        let actual = RepeatedStochasticInputs::new([10u32, 20], 3)
+            .into_par_iter()
+            .with_producer(CollectMixedEnds);
+        let expected = vec![
+            StochasticInput::new(10, 0),
+            StochasticInput::new(20, 2),
+            StochasticInput::new(10, 1),
+            StochasticInput::new(20, 1),
+            StochasticInput::new(10, 2),
+            StochasticInput::new(20, 0),
+        ];
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn repeated_parallel_producer_preserves_partially_consumed_ends() {
+        let from_front = RepeatedStochasticInputs::new([10u32, 20], 3)
+            .into_par_iter()
+            .with_producer(CollectCrossedEnd(CrossedEnd::Front));
+        let from_back = RepeatedStochasticInputs::new([10u32, 20], 3)
+            .into_par_iter()
+            .with_producer(CollectCrossedEnd(CrossedEnd::Back));
+
+        assert_eq!(from_front, vec![
+            StochasticInput::new(10, 0),
+            StochasticInput::new(20, 2),
+            StochasticInput::new(20, 1),
+            StochasticInput::new(20, 0),
+            StochasticInput::new(10, 2),
+            StochasticInput::new(10, 1),
+        ]);
+        assert_eq!(from_back, vec![
+            StochasticInput::new(20, 2),
+            StochasticInput::new(10, 0),
+            StochasticInput::new(10, 1),
+            StochasticInput::new(10, 2),
+            StochasticInput::new(20, 0),
+            StochasticInput::new(20, 1),
+        ]);
+    }
+
+    #[test]
+    fn repeated_parameter_splits_at_both_edges() {
+        let segment = RepeatedParameter::new(10u32, 0..3);
+        assert_eq!(segment.size_hint(), (3, Some(3)));
+        let (left, right) = segment.split_at(0);
+        assert!(left.is_none());
+        assert_eq!(right.as_ref().map(RepeatedParameter::len), Some(3));
+
+        let (left, right) = right
+            .expect("the zero split preserves the right segment")
+            .split_at(3);
+        assert_eq!(left.as_ref().map(RepeatedParameter::len), Some(3));
+        assert!(right.is_none());
+    }
+
+    #[test]
+    fn zero_repetitions_are_empty_without_consuming_parameters() {
+        let serial = RepeatedStochasticInputs::new(0..usize::MAX, 0).into_iter();
+        assert_eq!(serial.size_hint(), (0, Some(0)));
+        let serial = serial.collect::<Vec<_>>();
+        let parallel_inputs =
+            RepeatedStochasticInputs::new(0u32..usize::MAX as u32, 0).into_par_iter();
+        let split_lengths = parallel_inputs.with_producer(SplitEmpty);
+
+        assert!(serial.is_empty());
+        assert_eq!(split_lengths, (0, 0));
+    }
+
+    #[test]
+    #[should_panic(expected = "repeated stochastic input count overflow")]
+    fn parallel_repeated_inputs_reject_unrepresentable_length() {
+        let _ = RepeatedStochasticInputs::new([1u8, 2], usize::MAX).into_par_iter();
+    }
+}

--- a/crates/ssa-workflow/src/compute/stochastic/input/mod.rs
+++ b/crates/ssa-workflow/src/compute/stochastic/input/mod.rs
@@ -1,0 +1,112 @@
+//! Stochastic input identity and lazy repeated input sources.
+
+mod parallel;
+mod serial;
+
+pub use parallel::RepeatedStochasticIntoParIter;
+pub use serial::RepeatedStochasticIntoIter;
+
+use crate::cache::CanonicalEncode;
+
+/// Input for one stochastic execution.
+///
+/// This wraps a deterministic parameter value (`param`) with a `repetition_index`.
+///
+/// The pair serves two roles:
+///
+/// - It is the canonical input used for cache-key construction.
+/// - It selects one reproducible stochastic repetition.
+///
+/// # Encoding
+///
+/// Canonical encoding is `param` bytes followed by big-endian `repetition_index` bytes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StochasticInput<P> {
+    /// Deterministic model/config input.
+    pub param: P,
+    /// Repetition index used for random stream derivation.
+    pub repetition_index: u64,
+}
+
+impl<P> StochasticInput<P> {
+    /// Create a stochastic input from `(param, repetition_index)`.
+    pub const fn new(param: P, repetition_index: u64) -> Self {
+        Self {
+            param,
+            repetition_index,
+        }
+    }
+}
+
+impl<P> From<(P, u64)> for StochasticInput<P> {
+    fn from((param, repetition_index): (P, u64)) -> Self {
+        Self {
+            param,
+            repetition_index,
+        }
+    }
+}
+
+impl<P: CanonicalEncode> CanonicalEncode for StochasticInput<P> {
+    const SIZE: usize = P::SIZE + u64::SIZE;
+
+    unsafe fn encode_into(&self, buffer: &mut [u8]) {
+        unsafe {
+            self.param.encode_into(&mut buffer[..P::SIZE]);
+            self.repetition_index
+                .encode_into(&mut buffer[P::SIZE..Self::SIZE]);
+        }
+    }
+}
+
+/// Lazy ordered input source for repeated stochastic executions.
+///
+/// This source represents the logical Cartesian product of `params` and
+/// `0..repetitions` without materializing every [`StochasticInput`]. Items are emitted in
+/// parameter-major order: all repetitions for `params[0]`, then all repetitions for `params[1]`,
+/// and so on.
+///
+/// Converting the source into an indexed parallel iterator panics if the total number of repeated
+/// inputs cannot be represented by `usize`.
+#[derive(Debug, Clone)]
+pub struct RepeatedStochasticInputs<I> {
+    params: I,
+    repetitions: usize,
+}
+
+impl<I> RepeatedStochasticInputs<I> {
+    /// Create a lazy repeated stochastic input source.
+    pub const fn new(params: I, repetitions: usize) -> Self {
+        Self {
+            params,
+            repetitions,
+        }
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stochastic_input_constructors_encode_identically() {
+        let from_new = StochasticInput::new(123u64, 9);
+        let from_tuple: StochasticInput<u64> = (123u64, 9u64).into();
+        let from_fields = StochasticInput {
+            param: 123u64,
+            repetition_index: 9,
+        };
+
+        let mut buffer_new = vec![0u8; StochasticInput::<u64>::SIZE];
+        let mut buffer_tuple = vec![0u8; StochasticInput::<u64>::SIZE];
+        let mut buffer_fields = vec![0u8; StochasticInput::<u64>::SIZE];
+
+        let encoded_new = unsafe { from_new.encode_with_buffer(&mut buffer_new) };
+        let encoded_tuple = unsafe { from_tuple.encode_with_buffer(&mut buffer_tuple) };
+        let encoded_fields = unsafe { from_fields.encode_with_buffer(&mut buffer_fields) };
+
+        assert_eq!(encoded_new, encoded_tuple);
+        assert_eq!(encoded_new, encoded_fields);
+    }
+}

--- a/crates/ssa-workflow/src/compute/stochastic/input/parallel.rs
+++ b/crates/ssa-workflow/src/compute/stochastic/input/parallel.rs
@@ -1,5 +1,3 @@
-//! Stochastic input identity and lazy repeated input sources.
-
 use std::ops::Range;
 
 use rayon::{
@@ -7,161 +5,7 @@ use rayon::{
     prelude::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator},
 };
 
-use crate::cache::CanonicalEncode;
-
-/// Input for one stochastic execution.
-///
-/// This wraps a deterministic parameter value (`param`) with a `repetition_index`.
-///
-/// The pair serves two roles:
-///
-/// - It is the canonical input used for cache-key construction.
-/// - It selects one reproducible stochastic repetition.
-///
-/// # Encoding
-///
-/// Canonical encoding is `param` bytes followed by big-endian `repetition_index` bytes.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct StochasticInput<P> {
-    /// Deterministic model/config input.
-    pub param: P,
-    /// Repetition index used for random stream derivation.
-    pub repetition_index: u64,
-}
-
-impl<P> StochasticInput<P> {
-    /// Create a stochastic input from `(param, repetition_index)`.
-    pub const fn new(param: P, repetition_index: u64) -> Self {
-        Self {
-            param,
-            repetition_index,
-        }
-    }
-}
-
-impl<P> From<(P, u64)> for StochasticInput<P> {
-    fn from((param, repetition_index): (P, u64)) -> Self {
-        Self {
-            param,
-            repetition_index,
-        }
-    }
-}
-
-impl<P: CanonicalEncode> CanonicalEncode for StochasticInput<P> {
-    const SIZE: usize = P::SIZE + u64::SIZE;
-
-    unsafe fn encode_into(&self, buffer: &mut [u8]) {
-        unsafe {
-            self.param.encode_into(&mut buffer[..P::SIZE]);
-            self.repetition_index
-                .encode_into(&mut buffer[P::SIZE..Self::SIZE]);
-        }
-    }
-}
-
-/// Lazy ordered input source for repeated stochastic executions.
-///
-/// This source represents the logical Cartesian product of `params` and
-/// `0..repetitions` without materializing every [`StochasticInput`]. Items are emitted in
-/// parameter-major order: all repetitions for `params[0]`, then all repetitions for `params[1]`,
-/// and so on.
-///
-/// Converting the source into an indexed parallel iterator panics if the total number of repeated
-/// inputs cannot be represented by `usize`.
-#[derive(Debug, Clone)]
-pub struct RepeatedStochasticInputs<I> {
-    params: I,
-    repetitions: usize,
-}
-
-impl<I> RepeatedStochasticInputs<I> {
-    /// Create a lazy repeated stochastic input source.
-    pub const fn new(params: I, repetitions: usize) -> Self {
-        Self {
-            params,
-            repetitions,
-        }
-    }
-}
-
-impl<I> IntoIterator for RepeatedStochasticInputs<I>
-where
-    I: IntoIterator,
-    I::Item: Clone,
-{
-    type IntoIter = RepeatedStochasticIntoIter<I::IntoIter>;
-    type Item = StochasticInput<I::Item>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        RepeatedStochasticIntoIter {
-            params: self.params.into_iter(),
-            current_param: None,
-            repetitions: self.repetitions,
-            repetition_index: 0,
-        }
-    }
-}
-
-/// Serial iterator over a [`RepeatedStochasticInputs`] source.
-#[derive(Debug, Clone)]
-pub struct RepeatedStochasticIntoIter<I>
-where
-    I: Iterator,
-{
-    params: I,
-    current_param: Option<I::Item>,
-    repetitions: usize,
-    repetition_index: usize,
-}
-
-impl<I> Iterator for RepeatedStochasticIntoIter<I>
-where
-    I: Iterator,
-    I::Item: Clone,
-{
-    type Item = StochasticInput<I::Item>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.repetitions == 0 {
-            return None;
-        }
-
-        if self.current_param.is_none() {
-            self.current_param = self.params.next();
-            self.repetition_index = 0;
-        }
-
-        let param = self.current_param.as_ref()?.clone();
-        let repetition_index = self.repetition_index;
-        self.repetition_index += 1;
-
-        if self.repetition_index == self.repetitions {
-            self.current_param = None;
-        }
-
-        Some(StochasticInput::new(param, repetition_index as u64))
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        if self.repetitions == 0 {
-            return (0, Some(0));
-        }
-
-        let current_remaining = self
-            .current_param
-            .as_ref()
-            .map_or(0, |_| self.repetitions - self.repetition_index);
-        let (lower, upper) = self.params.size_hint();
-        let lower = lower
-            .saturating_mul(self.repetitions)
-            .saturating_add(current_remaining);
-        let upper = upper
-            .and_then(|value| value.checked_mul(self.repetitions))
-            .and_then(|value| value.checked_add(current_remaining));
-        (lower, upper)
-    }
-}
+use super::{RepeatedStochasticInputs, StochasticInput};
 
 impl<I> IntoParallelIterator for RepeatedStochasticInputs<I>
 where
@@ -627,38 +471,7 @@ where
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
-    use std::sync::{
-        Arc,
-        atomic::{AtomicUsize, Ordering},
-    };
-
     use super::*;
-
-    struct DualModeInputs {
-        values: Range<u32>,
-        serial_conversions: Arc<AtomicUsize>,
-        parallel_conversions: Arc<AtomicUsize>,
-    }
-
-    impl IntoIterator for DualModeInputs {
-        type IntoIter = Range<u32>;
-        type Item = u32;
-
-        fn into_iter(self) -> Self::IntoIter {
-            self.serial_conversions.fetch_add(1, Ordering::SeqCst);
-            self.values
-        }
-    }
-
-    impl IntoParallelIterator for DualModeInputs {
-        type Item = u32;
-        type Iter = <Range<u32> as IntoParallelIterator>::Iter;
-
-        fn into_par_iter(self) -> Self::Iter {
-            self.parallel_conversions.fetch_add(1, Ordering::SeqCst);
-            self.values.into_par_iter()
-        }
-    }
 
     enum SplitPattern {
         Prefix,
@@ -783,28 +596,7 @@ mod tests {
     }
 
     #[test]
-    fn stochastic_input_constructors_encode_identically() {
-        let from_new = StochasticInput::new(123u64, 9);
-        let from_tuple: StochasticInput<u64> = (123u64, 9u64).into();
-        let from_fields = StochasticInput {
-            param: 123u64,
-            repetition_index: 9,
-        };
-
-        let mut buffer_new = vec![0u8; StochasticInput::<u64>::SIZE];
-        let mut buffer_tuple = vec![0u8; StochasticInput::<u64>::SIZE];
-        let mut buffer_fields = vec![0u8; StochasticInput::<u64>::SIZE];
-
-        let encoded_new = unsafe { from_new.encode_with_buffer(&mut buffer_new) };
-        let encoded_tuple = unsafe { from_tuple.encode_with_buffer(&mut buffer_tuple) };
-        let encoded_fields = unsafe { from_fields.encode_with_buffer(&mut buffer_fields) };
-
-        assert_eq!(encoded_new, encoded_tuple);
-        assert_eq!(encoded_new, encoded_fields);
-    }
-
-    #[test]
-    fn repeated_inputs_support_standard_serial_and_parallel_iteration() {
+    fn repeated_inputs_are_indexed_and_parameter_major() {
         let inputs = RepeatedStochasticInputs::new(10u32..12, 2);
         let expected = vec![
             StochasticInput::new(10, 0),
@@ -813,8 +605,6 @@ mod tests {
             StochasticInput::new(11, 1),
         ];
         let expected_len = expected.len();
-
-        assert_eq!(inputs.clone().into_iter().collect::<Vec<_>>(), expected);
 
         let parallel_inputs = inputs.clone().into_par_iter();
         assert_eq!(parallel_inputs.opt_len(), Some(expected_len));
@@ -833,37 +623,6 @@ mod tests {
             .zip(0..expected_len)
             .collect::<Vec<_>>();
         assert_eq!(indexed_outputs, expected_indexed);
-    }
-
-    #[test]
-    fn repeated_inputs_use_the_selected_source_mode_directly() {
-        let serial_conversions = Arc::new(AtomicUsize::new(0));
-        let parallel_conversions = Arc::new(AtomicUsize::new(0));
-        let inputs = DualModeInputs {
-            values: 10..12,
-            serial_conversions: Arc::clone(&serial_conversions),
-            parallel_conversions: Arc::clone(&parallel_conversions),
-        };
-        let serial = RepeatedStochasticInputs::new(inputs, 2)
-            .into_iter()
-            .collect::<Vec<_>>();
-
-        assert_eq!(serial.len(), 4);
-        assert_eq!(serial_conversions.load(Ordering::SeqCst), 1);
-        assert_eq!(parallel_conversions.load(Ordering::SeqCst), 0);
-
-        let inputs = DualModeInputs {
-            values: 10..12,
-            serial_conversions: Arc::clone(&serial_conversions),
-            parallel_conversions: Arc::clone(&parallel_conversions),
-        };
-        let parallel = RepeatedStochasticInputs::new(inputs, 2)
-            .into_par_iter()
-            .collect::<Vec<_>>();
-
-        assert_eq!(parallel.len(), 4);
-        assert_eq!(serial_conversions.load(Ordering::SeqCst), 1);
-        assert_eq!(parallel_conversions.load(Ordering::SeqCst), 1);
     }
 
     #[test]
@@ -901,9 +660,14 @@ mod tests {
 
     #[test]
     fn repeated_parallel_producer_supports_recursive_boundary_splits() {
-        let expected = RepeatedStochasticInputs::new([10u32, 20], 3)
-            .into_iter()
-            .collect::<Vec<_>>();
+        let expected = vec![
+            StochasticInput::new(10, 0),
+            StochasticInput::new(10, 1),
+            StochasticInput::new(10, 2),
+            StochasticInput::new(20, 0),
+            StochasticInput::new(20, 1),
+            StochasticInput::new(20, 2),
+        ];
         let prefix_split = RepeatedStochasticInputs::new([10u32, 20], 3)
             .into_par_iter()
             .with_producer(CollectSplitPattern(SplitPattern::Prefix));
@@ -976,14 +740,10 @@ mod tests {
 
     #[test]
     fn zero_repetitions_are_empty_without_consuming_parameters() {
-        let serial = RepeatedStochasticInputs::new(0..usize::MAX, 0).into_iter();
-        assert_eq!(serial.size_hint(), (0, Some(0)));
-        let serial = serial.collect::<Vec<_>>();
         let parallel_inputs =
             RepeatedStochasticInputs::new(0u32..usize::MAX as u32, 0).into_par_iter();
         let split_lengths = parallel_inputs.with_producer(SplitEmpty);
 
-        assert!(serial.is_empty());
         assert_eq!(split_lengths, (0, 0));
     }
 

--- a/crates/ssa-workflow/src/compute/stochastic/input/serial.rs
+++ b/crates/ssa-workflow/src/compute/stochastic/input/serial.rs
@@ -1,0 +1,108 @@
+use super::{RepeatedStochasticInputs, StochasticInput};
+
+impl<I> IntoIterator for RepeatedStochasticInputs<I>
+where
+    I: IntoIterator,
+    I::Item: Clone,
+{
+    type IntoIter = RepeatedStochasticIntoIter<I::IntoIter>;
+    type Item = StochasticInput<I::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        RepeatedStochasticIntoIter {
+            params: self.params.into_iter(),
+            current_param: None,
+            repetitions: self.repetitions,
+            repetition_index: 0,
+        }
+    }
+}
+
+/// Serial iterator over a [`RepeatedStochasticInputs`] source.
+#[derive(Debug, Clone)]
+pub struct RepeatedStochasticIntoIter<I>
+where
+    I: Iterator,
+{
+    params: I,
+    current_param: Option<I::Item>,
+    repetitions: usize,
+    repetition_index: usize,
+}
+
+impl<I> Iterator for RepeatedStochasticIntoIter<I>
+where
+    I: Iterator,
+    I::Item: Clone,
+{
+    type Item = StochasticInput<I::Item>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.repetitions == 0 {
+            return None;
+        }
+
+        if self.current_param.is_none() {
+            self.current_param = self.params.next();
+            self.repetition_index = 0;
+        }
+
+        let param = self.current_param.as_ref()?.clone();
+        let repetition_index = self.repetition_index;
+        self.repetition_index += 1;
+
+        if self.repetition_index == self.repetitions {
+            self.current_param = None;
+        }
+
+        Some(StochasticInput::new(param, repetition_index as u64))
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        if self.repetitions == 0 {
+            return (0, Some(0));
+        }
+
+        let current_remaining = self
+            .current_param
+            .as_ref()
+            .map_or(0, |_| self.repetitions - self.repetition_index);
+        let (lower, upper) = self.params.size_hint();
+        let lower = lower
+            .saturating_mul(self.repetitions)
+            .saturating_add(current_remaining);
+        let upper = upper
+            .and_then(|value| value.checked_mul(self.repetitions))
+            .and_then(|value| value.checked_add(current_remaining));
+        (lower, upper)
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn repeated_inputs_are_parameter_major() {
+        let actual = RepeatedStochasticInputs::new(10u32..12, 2)
+            .into_iter()
+            .collect::<Vec<_>>();
+        let expected = vec![
+            StochasticInput::new(10, 0),
+            StochasticInput::new(10, 1),
+            StochasticInput::new(11, 0),
+            StochasticInput::new(11, 1),
+        ];
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn zero_repetitions_are_empty_without_consuming_parameters() {
+        let iter = RepeatedStochasticInputs::new(0..usize::MAX, 0).into_iter();
+
+        assert_eq!(iter.size_hint(), (0, Some(0)));
+        assert_eq!(iter.collect::<Vec<_>>(), []);
+    }
+}

--- a/crates/ssa-workflow/src/compute/stochastic/mod.rs
+++ b/crates/ssa-workflow/src/compute/stochastic/mod.rs
@@ -111,9 +111,11 @@
 //! Within one stream, random values are consumed sequentially; changing how many values that stream
 //! consumes can change later values from the same stream.
 
+pub mod input;
+
 use std::marker::PhantomData;
 
-use rayon::prelude::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};
+pub use input::{RepeatedStochasticInputs, StochasticInput};
 
 use crate::{
     BatchExecution, Compute, Result,
@@ -128,57 +130,6 @@ use crate::{
 type BuildStochasticTask<CP, P, O, S, F> =
     StochasticTask<<CP as CacheProvider<O>>::Cache, P, O, S, F>;
 
-/// Input for one stochastic execution.
-///
-/// This wraps a deterministic parameter value (`param`) with a `repetition_index`.
-///
-/// The pair serves two roles:
-///
-/// - It is the canonical input used for cache-key construction.
-/// - It selects one reproducible stochastic repetition.
-///
-/// # Encoding
-///
-/// Canonical encoding is `param` bytes followed by big-endian `repetition_index` bytes.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct StochasticInput<P> {
-    /// Deterministic model/config input.
-    pub param: P,
-    /// Repetition index used for random stream derivation.
-    pub repetition_index: u64,
-}
-
-impl<P> StochasticInput<P> {
-    /// Create a stochastic input from `(param, repetition_index)`.
-    pub const fn new(param: P, repetition_index: u64) -> Self {
-        Self {
-            param,
-            repetition_index,
-        }
-    }
-}
-
-impl<P> From<(P, u64)> for StochasticInput<P> {
-    fn from((param, repetition_index): (P, u64)) -> Self {
-        Self {
-            param,
-            repetition_index,
-        }
-    }
-}
-
-impl<P: CanonicalEncode> CanonicalEncode for StochasticInput<P> {
-    const SIZE: usize = P::SIZE + u64::SIZE;
-
-    unsafe fn encode_into(&self, buffer: &mut [u8]) {
-        unsafe {
-            self.param.encode_into(&mut buffer[..P::SIZE]);
-            self.repetition_index
-                .encode_into(&mut buffer[P::SIZE..Self::SIZE]);
-        }
-    }
-}
-
 /// Convenience methods for computations keyed by [`StochasticInput`].
 ///
 /// This trait is implemented for every [`Compute`] node, including stochastic tasks and
@@ -188,26 +139,41 @@ impl<P: CanonicalEncode> CanonicalEncode for StochasticInput<P> {
 pub trait StochasticComputeExt: Compute {
     /// Start a batch execution for `repetitions` stochastic repetitions of one deterministic input.
     ///
-    /// The batch uses `0..repetitions` as its indexed parallel input range and converts each item
-    /// to `StochasticInput::new(param.clone(), index as u64)`. Collected outputs therefore
-    /// remain in repetition-index order while the stochastic identity continues to use a
-    /// platform-stable `u64` repetition id.
+    /// The batch lazily generates `StochasticInput::new(param.clone(), index as u64)` for each
+    /// repetition. Collected outputs therefore remain in repetition-index order while the
+    /// stochastic identity continues to use a platform-stable `u64` repetition id.
     fn with_repeated_input<P>(
         &self,
         param: P,
         repetitions: usize,
-    ) -> BatchExecution<'_, Self, impl IndexedParallelIterator<Item = StochasticInput<P>>>
+    ) -> BatchExecution<'_, Self, RepeatedStochasticInputs<[P; 1]>>
     where
         Self: Sized + Compute<Input = StochasticInput<P>>,
-        P: Clone + Send,
+        P: Clone,
     {
-        self.with_inputs(
-            (0..repetitions)
-                .into_par_iter()
-                .map_with(param, |param, index| {
-                    StochasticInput::new(param.clone(), index as u64)
-                }),
-        )
+        self.with_inputs(RepeatedStochasticInputs::new([param], repetitions))
+    }
+
+    /// Start a batch execution for `repetitions` stochastic repetitions of each parameter.
+    ///
+    /// The batch consumes `params` directly through its serial or indexed parallel conversion and
+    /// lazily emits inputs in parameter-major order. It does not materialize the parameter source
+    /// or the full `params.len() * repetitions` input grid.
+    ///
+    /// # Panics
+    ///
+    /// Parallel collection panics if the total number of repeated inputs cannot be represented by
+    /// `usize`.
+    fn with_repeated_inputs<P, I>(
+        &self,
+        params: I,
+        repetitions: usize,
+    ) -> BatchExecution<'_, Self, RepeatedStochasticInputs<I>>
+    where
+        Self: Sized + Compute<Input = StochasticInput<P>>,
+        P: Clone,
+    {
+        self.with_inputs(RepeatedStochasticInputs::new(params, repetitions))
     }
 }
 
@@ -505,10 +471,39 @@ mod tests {
 
             let inputs: Vec<_> = (0..128u64).map(|i| StochasticInput::new((), i)).collect();
 
-            let outputs1 = task1.with_inputs(inputs.clone()).collect()?;
-            let outputs2 = task2.with_inputs(inputs).collect()?;
+            let outputs1 = task1
+                .with_inputs(inputs.clone())
+                .collect::<Result<Vec<_>>>()?;
+            let outputs2 = task2.with_inputs(inputs).collect::<Result<Vec<_>>>()?;
 
             assert_eq!(outputs1, outputs2);
+            Ok(())
+        }
+
+        #[test]
+        fn repeated_inputs_are_parameter_major_and_lazy_schedulable() -> Result<()> {
+            let mut expected_task = StochasticTask::builder("repeated-inputs-order-v1")
+                .function(|rng, param| Ok((param, rng.next_u64())))
+                .build()?;
+            let task = StochasticTask::builder("repeated-inputs-order-v1")
+                .function(|rng, param| Ok((param, rng.next_u64())))
+                .build()?;
+
+            let expected = vec![
+                expected_task.execute_one(StochasticInput::new(10u32, 0))?,
+                expected_task.execute_one(StochasticInput::new(10u32, 1))?,
+                expected_task.execute_one(StochasticInput::new(20u32, 0))?,
+                expected_task.execute_one(StochasticInput::new(20u32, 1))?,
+            ];
+            let serial = task
+                .with_repeated_inputs(vec![10u32, 20], 2)
+                .collect_serial::<Result<Vec<_>>>()?;
+            let parallel = task
+                .with_repeated_inputs(vec![10u32, 20], 2)
+                .collect::<Result<Vec<_>>>()?;
+
+            assert_eq!(serial, expected);
+            assert_eq!(parallel, expected);
             Ok(())
         }
 
@@ -529,31 +524,6 @@ mod tests {
             assert_eq!(task.execute_one(input.clone())?, task.execute_one(input)?);
             assert_eq!(call_count.load(Ordering::SeqCst), 2);
             Ok(())
-        }
-    }
-
-    mod input_encoding {
-        use super::*;
-
-        #[test]
-        fn test_stochastic_input_from_tuple_matches_new_encoding() {
-            let from_new = StochasticInput::new(123u64, 9);
-            let from_tuple: StochasticInput<u64> = (123u64, 9u64).into();
-            let from_fields = StochasticInput {
-                param: 123u64,
-                repetition_index: 9,
-            };
-
-            let mut buffer_new = vec![0u8; StochasticInput::<u64>::SIZE];
-            let mut buffer_tuple = vec![0u8; StochasticInput::<u64>::SIZE];
-            let mut buffer_fields = vec![0u8; StochasticInput::<u64>::SIZE];
-
-            let encoded_new = unsafe { from_new.encode_with_buffer(&mut buffer_new) };
-            let encoded_tuple = unsafe { from_tuple.encode_with_buffer(&mut buffer_tuple) };
-            let encoded_fields = unsafe { from_fields.encode_with_buffer(&mut buffer_fields) };
-
-            assert_eq!(encoded_new, encoded_tuple);
-            assert_eq!(encoded_new, encoded_fields);
         }
     }
 }

--- a/crates/ssa-workflow/src/compute/stochastic/mod.rs
+++ b/crates/ssa-workflow/src/compute/stochastic/mod.rs
@@ -156,14 +156,14 @@ pub trait StochasticComputeExt: Compute {
 
     /// Start a batch execution for `repetitions` stochastic repetitions of each parameter.
     ///
-    /// The batch consumes `params` directly through its serial or indexed parallel conversion and
-    /// lazily emits inputs in parameter-major order. It does not materialize the parameter source
-    /// or the full `params.len() * repetitions` input grid.
+    /// The batch consumes `params` through its serial or indexed parallel conversion and lazily
+    /// emits inputs in parameter-major order. This adapter does not collect the parameter source or
+    /// materialize the full `params.len() * repetitions` input grid.
     ///
     /// # Panics
     ///
-    /// Parallel collection panics if the total number of repeated inputs cannot be represented by
-    /// `usize`.
+    /// Parallel conversion or collection panics if the total number of repeated inputs cannot be
+    /// represented by `usize`.
     fn with_repeated_inputs<P, I>(
         &self,
         params: I,

--- a/crates/ssa-workflow/src/compute/transform/tests.rs
+++ b/crates/ssa-workflow/src/compute/transform/tests.rs
@@ -66,7 +66,7 @@ fn test_transform_source_and_transform_cache_split() -> Result<()> {
             .build()?
     };
 
-    let results1 = transform1.with_inputs(0..3).collect()?;
+    let results1 = transform1.with_inputs(0..3).collect::<Result<Vec<_>>>()?;
 
     let expected: Vec<String> = (0..3).map(|i| format!("Result: {}", i * 2)).collect();
     assert_eq!(results1, expected);
@@ -85,7 +85,7 @@ fn test_transform_source_and_transform_cache_split() -> Result<()> {
             .build()?
     };
 
-    let results2 = transform2.with_inputs(0..3).collect()?;
+    let results2 = transform2.with_inputs(0..3).collect::<Result<Vec<_>>>()?;
 
     assert_eq!(results2, expected);
     assert_eq!(stage1_calls.load(Ordering::SeqCst), 3);
@@ -105,7 +105,7 @@ fn test_transform_with_different_types() -> Result<()> {
         .cache(ManagedHashCache::<String>::default())
         .build()?;
 
-    let results = transform.with_inputs(0..5u32).collect()?;
+    let results = transform.with_inputs(0..5u32).collect::<Result<Vec<_>>>()?;
 
     let expected: Vec<String> = (0..5u32).map(|i| format!("Value: {}", i * 100)).collect();
     assert_eq!(results, expected);

--- a/crates/ssa-workflow/src/prelude.rs
+++ b/crates/ssa-workflow/src/prelude.rs
@@ -18,8 +18,8 @@ pub use crate::{
     Compute, InterruptSignal,
     cache::{CanonicalEncode, StorageProviderExt, memory::ManagedHashCache},
     compute::{
-        DependentInput, DependentStochasticInput, DeterministicTask, RandomVariable, RngBundle,
-        StochasticComputeExt, StochasticInput, StochasticTask, StochasticTransform, Transform,
-        TransformExt,
+        DependentInput, DependentStochasticInput, DeterministicTask, RandomVariable,
+        RepeatedStochasticInputs, RngBundle, StochasticComputeExt, StochasticInput, StochasticTask,
+        StochasticTransform, Transform, TransformExt,
     },
 };

--- a/crates/ssa-workflow/tests/cache_integration.rs
+++ b/crates/ssa-workflow/tests/cache_integration.rs
@@ -132,8 +132,8 @@ fn encoded_cache_uses_configured_fresh_codec_in_parallel_execution() -> Result<(
         )))
         .build()?;
 
-    let outputs1 = compute.with_inputs(0..8usize).collect()?;
-    let outputs2 = compute.with_inputs(0..8usize).collect()?;
+    let outputs1 = compute.with_inputs(0..8usize).collect::<Result<Vec<_>>>()?;
+    let outputs2 = compute.with_inputs(0..8usize).collect::<Result<Vec<_>>>()?;
 
     let expected: Vec<_> = (0..8usize).map(|i| i + 10).collect();
     assert_eq!(outputs1, expected);

--- a/crates/ssa-workflow/tests/execution_integration.rs
+++ b/crates/ssa-workflow/tests/execution_integration.rs
@@ -58,7 +58,7 @@ fn prelude_smoke_supports_execute_one_and_batch_collect() -> Result<()> {
 
     assert_eq!(task.execute_one(3usize)?, 12);
 
-    let outputs: Vec<usize> = task.with_inputs(0..4usize).collect()?;
+    let outputs: Vec<usize> = task.with_inputs(0..4usize).collect::<Result<Vec<_>>>()?;
 
     assert_eq!(outputs, vec![0, 4, 8, 12]);
     assert_eq!(call_count.load(Ordering::SeqCst), 4);
@@ -72,7 +72,9 @@ fn stochastic_repeated_input_collects_in_repetition_order() -> Result<()> {
         .cache(RepetitionIndexProvider)
         .build()?;
 
-    let outputs: Vec<u64> = task.with_repeated_input(42u32, 5).collect()?;
+    let outputs: Vec<u64> = task
+        .with_repeated_input(42u32, 5)
+        .collect::<Result<Vec<_>>>()?;
 
     assert_eq!(outputs, vec![0, 1, 2, 3, 4]);
     Ok(())
@@ -91,7 +93,9 @@ fn stochastic_repeated_input_zero_repetitions_is_empty() -> Result<()> {
         .cache(ManagedHashCache::<u64>::default())
         .build()?;
 
-    let outputs: Vec<u64> = task.with_repeated_input((), 0).collect()?;
+    let outputs: Vec<u64> = task
+        .with_repeated_input((), 0)
+        .collect::<Result<Vec<_>>>()?;
 
     assert!(outputs.is_empty());
     assert_eq!(call_count.load(Ordering::SeqCst), 0);
@@ -122,13 +126,17 @@ fn stochastic_transform_reuses_cached_analysis() -> Result<()> {
 
     let repetitions = 8;
 
-    let results1: Vec<u32> = transform.with_repeated_input((), repetitions).collect()?;
+    let results1: Vec<u32> = transform
+        .with_repeated_input((), repetitions)
+        .collect::<Result<Vec<_>>>()?;
 
     assert_eq!(results1.len(), repetitions);
     assert_eq!(experiment_calls.load(Ordering::SeqCst), repetitions);
     assert_eq!(analysis_calls.load(Ordering::SeqCst), repetitions);
 
-    let results2: Vec<u32> = transform.with_repeated_input((), repetitions).collect()?;
+    let results2: Vec<u32> = transform
+        .with_repeated_input((), repetitions)
+        .collect::<Result<Vec<_>>>()?;
 
     assert_eq!(results1, results2);
     assert_eq!(experiment_calls.load(Ordering::SeqCst), repetitions);

--- a/crates/ssa-workflow/tests/managed_cache_identity.rs
+++ b/crates/ssa-workflow/tests/managed_cache_identity.rs
@@ -136,8 +136,10 @@ fn managed_transform_uses_child_path_for_output_space() -> Result<()> {
         .build()?;
 
     let inputs: Vec<_> = (0..8usize).collect();
-    let first = transform.with_inputs(inputs.clone()).collect()?;
-    let second = transform.with_inputs(inputs).collect()?;
+    let first = transform
+        .with_inputs(inputs.clone())
+        .collect::<Result<Vec<_>>>()?;
+    let second = transform.with_inputs(inputs).collect::<Result<Vec<_>>>()?;
 
     assert_eq!(first, second);
     assert_eq!(first, (0..8usize).map(|i| i * 2 + 1).collect::<Vec<_>>());

--- a/crates/ssa-workflow/tests/ssa_workflow.rs
+++ b/crates/ssa-workflow/tests/ssa_workflow.rs
@@ -81,7 +81,7 @@ fn birth_death_ssa_transform_is_reproducible_and_cached() -> Result<()> {
 
     let first_run: Vec<SsaSummary> = transform
         .with_repeated_input((INITIAL_CELLS, MAX_EVENTS), input_count)
-        .collect()?;
+        .collect::<Result<Vec<_>>>()?;
 
     assert_eq!(first_run.len(), input_count);
     assert!(first_run.iter().all(|summary| summary.events <= MAX_EVENTS));
@@ -95,7 +95,7 @@ fn birth_death_ssa_transform_is_reproducible_and_cached() -> Result<()> {
 
     let second_run: Vec<SsaSummary> = transform
         .with_repeated_input((INITIAL_CELLS, MAX_EVENTS), input_count)
-        .collect()?;
+        .collect::<Result<Vec<_>>>()?;
 
     assert_eq!(first_run, second_run);
     assert_eq!(ssa_calls.load(Ordering::SeqCst), input_count);


### PR DESCRIPTION
## Summary

Add collection-style batch scheduling to `ssa-workflow`, allowing callers to run ordered inputs serially, in the current Rayon pool, or in an explicit Rayon thread pool.

## Changes

- Add generic `collect<T>`, `collect_in<T>`, and `collect_serial<T>` batch terminals.
- Rename the lazy parallel escape hatch from `execute()` to `into_par_iter()`.
- Use standard collection semantics: `Result<Vec<_>>` short-circuits on errors, while `Vec<Result<_>>` retains every item result.
- Preserve interrupt handling for serial and parallel execution.
- Add fully lazy, parameter-major repeated stochastic inputs for serial and indexed parallel scheduling.
- Keep ordered parallel inputs and outputs positionally aligned through `IndexedParallelIterator`.
- Split stochastic input types, serial iteration, and Rayon producer plumbing into focused modules.
- Update README examples, doctests, and integration tests for the new API.

## Validation

- `cargo +nightly fmt --all -- --check`
- `cargo test --workspace --all-features`
- `cargo clippy -p ssa-workflow --all-targets --all-features -- -D warnings`
- `cargo +nightly llvm-cov -p ssa-workflow`
- `git diff --check`
