### PR TITLE
feat(ssa-workflow)!: make numeric canonical encodings order-preserving

### DIFF
--- a/crates/ssa-workflow/README.md
+++ b/crates/ssa-workflow/README.md
@@ -152,11 +152,22 @@ let task = DeterministicTask::builder("summary-statistics-v1")
 # }
 ```
 
-Identifiers use stable segments with ASCII letters, digits, and `-`; `_` is reserved for derived cache names. Prefer lowercase kebab-case and bump the version when the meaning of a result changes. Persistent namespace names use `_` between path or codec segments and `__` between the computation path and codec format.
+Identifiers use stable segments with ASCII letters, digits, and `-`; `_` is reserved for derived cache names. Prefer lowercase kebab-case and bump the version when the meaning of a result changes. Persistent namespace names use `_` between path or codec segments and `__` between the computation path, canonical key format, and codec format.
 
 Dependent computation paths render from the current result back to their roots. For example, a transform id `summary-v1` built from a task id `trajectory-v1` renders as `summary-v1_trajectory-v1`, read as "summary of trajectory". Persistent namespaces and RNG seed material use this same segment order.
 
 If you change compute logic, output type, or persistent encoding incompatibly, use a new computation id or codec format so old cached bytes are not reused as a different result.
+
+## Canonical Key Encoding
+
+Canonical input bytes serve as persistent cache keys and as input to stochastic RNG derivation. Built-in numeric encodings are lexicographically order-preserving: if `a < b` numerically, then `encode(a) < encode(b)` in unsigned byte order. This allows ordered storage backends to preserve numeric sweep locality when walking keys.
+
+- Unsigned integers: big-endian bytes.
+- Signed integers: big-endian two's-complement with the sign bit flipped.
+- Floats: NaN normalized to one canonical payload, `-0.0` treated as `+0.0`, then sign-magnitude transformed so the canonical order is `-inf < finite negatives < 0 < finite positives < +inf < NaN`.
+- Tuples and arrays: field concatenation; lexicographic ordering is inherited from component encodings.
+
+Persistent namespaces include a canonical-key-format version (`keyfmt-v2`). The order-preserving encoding is incompatible with the legacy raw big-endian format: signed-integer and floating-point inputs produce new cache keys and new stochastic RNG streams. Old namespaces are isolated and cannot be read through the new format.
 
 ## Transforms
 

--- a/crates/ssa-workflow/README.md
+++ b/crates/ssa-workflow/README.md
@@ -167,7 +167,7 @@ Canonical input bytes serve as persistent cache keys and as input to stochastic 
 - Floats: NaN normalized to one canonical payload, `-0.0` treated as `+0.0`, then sign-magnitude transformed so the canonical order is `-inf < finite negatives < 0 < finite positives < +inf < NaN`.
 - Tuples and arrays: field concatenation; lexicographic ordering is inherited from component encodings.
 
-Persistent namespaces include a canonical-key-format version (`keyfmt-v2`). The order-preserving encoding is incompatible with the legacy raw big-endian format: signed-integer and floating-point inputs produce new cache keys and new stochastic RNG streams. Old namespaces are isolated and cannot be read through the new format.
+Persistent namespaces include a canonical-key-format version (`keyfmt-v2`) so that different key encoding formats are always isolated into separate namespaces.
 
 ## Transforms
 

--- a/crates/ssa-workflow/src/cache/canonical_encode.rs
+++ b/crates/ssa-workflow/src/cache/canonical_encode.rs
@@ -189,16 +189,19 @@ macro_rules! impl_encode_for_signed {
 impl_encode_for_signed!(i8 => 1, i16 => 2, i32 => 4, i64 => 8, isize => 8, i128 => 16);
 
 macro_rules! impl_encode_for_float {
-    ($($t:ident => $size:literal),+ $(,)?) => {
+    ($($t:ident => $size:literal => $canonical_nan_bits:expr),+ $(,)?) => {
         $(
             impl CanonicalEncode for $t {
                 const SIZE: usize = $size;
 
                 #[inline]
                 unsafe fn encode_into(&self, buffer: &mut [u8]) {
-                    // Normalize: all NaN payloads to one canonical NaN, -0.0 to +0.0.
+                    // Normalize: all NaN payloads to one canonical positive quiet NaN,
+                    // -0.0 to +0.0. We use an explicit bit pattern rather than `$t::NAN.to_bits()`
+                    // because the Rust std docs state that NAN's sign and payload are arbitrary
+                    // and may change across versions and targets.
                     let bits = if self.is_nan() {
-                        $t::NAN.to_bits()
+                        $canonical_nan_bits
                     } else if *self == 0.0 {
                         0
                     } else {
@@ -224,7 +227,12 @@ macro_rules! impl_encode_for_float {
     };
 }
 
-impl_encode_for_float!(f32 => 4, f64 => 8);
+// Canonical NaN bit patterns: positive quiet NaN (sign=0, exponent=all-ones, quiet bit=1,
+// payload=0).
+impl_encode_for_float!(
+    f32 => 4 => 0x7fc0_0000u32,
+    f64 => 8 => 0x7ff8_0000_0000_0000u64,
+);
 
 macro_rules! impl_encode_for_tuple {
     ($($T:ident $idx:tt),+) => {

--- a/crates/ssa-workflow/src/cache/canonical_encode.rs
+++ b/crates/ssa-workflow/src/cache/canonical_encode.rs
@@ -424,7 +424,19 @@ mod tests {
 
         #[test]
         fn signed_i8_encoding_preserves_numeric_order() {
-            let values: Vec<i8> = vec![i8::MIN, -100, -2, -1, 0, 1, 2, 100, i8::MAX];
+            let values: Vec<i8> = vec![
+                i8::MIN,
+                i8::MIN + 1,
+                -100,
+                -2,
+                -1,
+                0,
+                1,
+                2,
+                100,
+                i8::MAX - 1,
+                i8::MAX,
+            ];
             let encoded: Vec<Vec<u8>> = values.iter().map(encode).collect();
             for window in encoded.windows(2) {
                 assert!(window[0] < window[1], "order violated");
@@ -433,7 +445,19 @@ mod tests {
 
         #[test]
         fn signed_i16_encoding_preserves_numeric_order() {
-            let values: Vec<i16> = vec![i16::MIN, -1000, -2, -1, 0, 1, 2, 1000, i16::MAX];
+            let values: Vec<i16> = vec![
+                i16::MIN,
+                i16::MIN + 1,
+                -1000,
+                -2,
+                -1,
+                0,
+                1,
+                2,
+                1000,
+                i16::MAX - 1,
+                i16::MAX,
+            ];
             let encoded: Vec<Vec<u8>> = values.iter().map(encode).collect();
             for window in encoded.windows(2) {
                 assert!(window[0] < window[1], "order violated");
@@ -442,7 +466,19 @@ mod tests {
 
         #[test]
         fn signed_i32_encoding_preserves_numeric_order() {
-            let values: Vec<i32> = vec![i32::MIN, -100_000, -2, -1, 0, 1, 2, 100_000, i32::MAX];
+            let values: Vec<i32> = vec![
+                i32::MIN,
+                i32::MIN + 1,
+                -100_000,
+                -2,
+                -1,
+                0,
+                1,
+                2,
+                100_000,
+                i32::MAX - 1,
+                i32::MAX,
+            ];
             let encoded: Vec<Vec<u8>> = values.iter().map(encode).collect();
             for window in encoded.windows(2) {
                 assert!(window[0] < window[1], "order violated");
@@ -453,6 +489,7 @@ mod tests {
         fn signed_i64_encoding_preserves_numeric_order() {
             let values: Vec<i64> = vec![
                 i64::MIN,
+                i64::MIN + 1,
                 -1_000_000_000,
                 -2,
                 -1,
@@ -460,6 +497,7 @@ mod tests {
                 1,
                 2,
                 1_000_000_000,
+                i64::MAX - 1,
                 i64::MAX,
             ];
             let encoded: Vec<Vec<u8>> = values.iter().map(encode).collect();
@@ -472,6 +510,7 @@ mod tests {
         fn signed_i128_encoding_preserves_numeric_order() {
             let values: Vec<i128> = vec![
                 i128::MIN,
+                i128::MIN + 1,
                 -1_000_000_000_000_000_000,
                 -2,
                 -1,
@@ -479,6 +518,7 @@ mod tests {
                 1,
                 2,
                 1_000_000_000_000_000_000,
+                i128::MAX - 1,
                 i128::MAX,
             ];
             let encoded: Vec<Vec<u8>> = values.iter().map(encode).collect();
@@ -559,12 +599,15 @@ mod tests {
 
         #[test]
         fn f32_encoding_preserves_canonical_order() {
+            let smallest_subnormal = f32::from_bits(1);
             let values: Vec<f32> = vec![
                 f32::NEG_INFINITY,
                 -1e30,
                 -1.5,
                 -f32::MIN_POSITIVE,
+                -smallest_subnormal,
                 0.0,
+                smallest_subnormal,
                 f32::MIN_POSITIVE,
                 1.5,
                 1e30,
@@ -584,12 +627,15 @@ mod tests {
 
         #[test]
         fn f64_encoding_preserves_canonical_order() {
+            let smallest_subnormal = f64::from_bits(1);
             let values: Vec<f64> = vec![
                 f64::NEG_INFINITY,
                 -1e300,
                 -1.5,
                 -f64::MIN_POSITIVE,
+                -smallest_subnormal,
                 0.0,
+                smallest_subnormal,
                 f64::MIN_POSITIVE,
                 1.5,
                 1e300,
@@ -615,6 +661,7 @@ mod tests {
 
         #[test]
         fn all_nan_payloads_encode_identically() {
+            // Positive quiet NaNs with different payloads.
             let nan_a = f32::from_bits(0x7fc0_0001);
             let nan_b = f32::from_bits(0x7fc0_dead);
             assert_eq!(encode(&nan_a), encode(&nan_b));
@@ -624,6 +671,20 @@ mod tests {
             let nan_d = f64::from_bits(0x7ff8_dead_beef_0000);
             assert_eq!(encode(&nan_c), encode(&nan_d));
             assert_eq!(encode(&nan_c), encode(&f64::NAN));
+
+            // Signaling NaNs (exponent all-ones, mantissa nonzero but quiet bit clear).
+            let snan_f32 = f32::from_bits(0x7f80_0001);
+            assert_eq!(encode(&snan_f32), encode(&f32::NAN));
+
+            let snan_f64 = f64::from_bits(0x7ff0_0000_0000_0001);
+            assert_eq!(encode(&snan_f64), encode(&f64::NAN));
+
+            // Negative NaNs (sign bit set).
+            let neg_nan_f32 = f32::from_bits(0xffc0_0001);
+            assert_eq!(encode(&neg_nan_f32), encode(&f32::NAN));
+
+            let neg_nan_f64 = f64::from_bits(0xfff8_0000_0000_0001);
+            assert_eq!(encode(&neg_nan_f64), encode(&f64::NAN));
         }
     }
 

--- a/crates/ssa-workflow/src/cache/canonical_encode.rs
+++ b/crates/ssa-workflow/src/cache/canonical_encode.rs
@@ -1,3 +1,11 @@
+/// Canonical key format version embedded in every persistent namespace.
+///
+/// Bumping this constant isolates all new cache entries from namespaces written under an older
+/// key encoding. The current version (`keyfmt-v2`) corresponds to the order-preserving numeric
+/// encoding introduced for signed integers and floating-point values. The legacy raw big-endian
+/// encoding is implicitly `keyfmt-v1` and is no longer produced.
+pub(crate) const CANONICAL_KEY_FORMAT: &str = "keyfmt-v2";
+
 /// Encode a key into canonical bytes.
 ///
 /// Implementations should be deterministic and consistent across different builds and runs, and
@@ -8,12 +16,28 @@
 /// `ssa-workflow` targets 64-bit platforms only. This avoids platform-dependent key encodings
 /// such as `usize` width and makes cache keys stable across builds.
 ///
-/// # Implementations
+/// # Order-preserving guarantee
 ///
-/// - For integers, the encoding is big-endian;
-/// - For floats, NaN values are normalized to a canonical NaN, and -0.0 is treated as +0.0.
-/// - For tuples and arrays, the encoding is the concatenation of the encodings of each element.
-/// - For custom structs, [`CanonicalEncodeWriter`] can write each field in sequence.
+/// Built-in numeric encodings are lexicographically order-preserving: if `a < b` in the natural
+/// numeric order, then `encode(a) < encode(b)` in unsigned byte-lexicographic order. This allows
+/// storage backends to preserve numeric sweep locality when walking keys.
+///
+/// - Unsigned integers: big-endian bytes (naturally order-preserving).
+/// - Signed integers: big-endian two's-complement bytes with the most-significant sign bit flipped.
+/// - Floating-point values: NaN payloads are normalized to one canonical NaN and `-0.0` is treated
+///   as `+0.0`. The resulting canonical order is: `-inf < finite negatives < 0 < finite positives <
+///   +inf < canonical NaN`.
+/// - Tuples and arrays: concatenation of element encodings; lexicographic ordering is inherited
+///   whenever every component encoding is order-preserving.
+///
+/// User-defined `CanonicalEncode` implementations are not required to define a natural order.
+///
+/// # Breaking change (key format v2)
+///
+/// The order-preserving encoding for signed integers and floats is incompatible with the legacy
+/// raw big-endian encoding. Canonical bytes also feed RNG derivation, so signed-integer and
+/// floating-point inputs produce new stochastic streams. Persistent namespaces include a
+/// canonical-key-format version that isolates new entries from old ones.
 pub trait CanonicalEncode {
     const SIZE: usize;
 
@@ -123,7 +147,10 @@ impl<'a> CanonicalEncodeWriter<'a> {
     }
 }
 
-macro_rules! impl_encode_for_int {
+#[cfg(not(target_pointer_width = "64"))]
+compile_error!("ssa-workflow supports only 64-bit targets");
+
+macro_rules! impl_encode_for_unsigned {
     ($($t:path => $size:literal),+ $(,)?) => {
         $(
             impl CanonicalEncode for $t {
@@ -138,11 +165,28 @@ macro_rules! impl_encode_for_int {
     };
 }
 
-impl_encode_for_int!(u8 => 1, u16 => 2, u32 => 4, u64 => 8, usize => 8, u128 => 16);
-impl_encode_for_int!(i8 => 1, i16 => 2, i32 => 4, i64 => 8, isize => 8, i128 => 16);
+impl_encode_for_unsigned!(u8 => 1, u16 => 2, u32 => 4, u64 => 8, usize => 8, u128 => 16);
 
-#[cfg(not(target_pointer_width = "64"))]
-compile_error!("ssa-workflow supports only 64-bit targets");
+macro_rules! impl_encode_for_signed {
+    ($($t:path => $size:literal),+ $(,)?) => {
+        $(
+            impl CanonicalEncode for $t {
+                const SIZE: usize = $size;
+
+                #[inline]
+                unsafe fn encode_into(&self, buffer: &mut [u8]) {
+                    let mut bytes = self.to_be_bytes();
+                    // Flip the most-significant sign bit so that the byte-lexicographic order
+                    // matches the natural numeric order: MIN encodes lowest, MAX encodes highest.
+                    bytes[0] ^= 0x80;
+                    unsafe { buffer.get_unchecked_mut(..$size) }.copy_from_slice(&bytes);
+                }
+            }
+        )+
+    };
+}
+
+impl_encode_for_signed!(i8 => 1, i16 => 2, i32 => 4, i64 => 8, isize => 8, i128 => 16);
 
 macro_rules! impl_encode_for_float {
     ($($t:ident => $size:literal),+ $(,)?) => {
@@ -152,6 +196,7 @@ macro_rules! impl_encode_for_float {
 
                 #[inline]
                 unsafe fn encode_into(&self, buffer: &mut [u8]) {
+                    // Normalize: all NaN payloads to one canonical NaN, -0.0 to +0.0.
                     let bits = if self.is_nan() {
                         $t::NAN.to_bits()
                     } else if *self == 0.0 {
@@ -159,7 +204,20 @@ macro_rules! impl_encode_for_float {
                     } else {
                         self.to_bits()
                     };
-                    unsafe { buffer.get_unchecked_mut(..$size) }.copy_from_slice(&bits.to_be_bytes());
+
+                    // Order-preserving transformation:
+                    // - Negative values (sign bit set): invert all bits.
+                    // - Non-negative values (sign bit clear): flip only the sign bit.
+                    //
+                    // This yields: -inf < finite negatives < 0 < finite positives < +inf < NaN.
+                    let sign_bit = 1 << ($size * 8 - 1);
+                    let encoded = if bits & sign_bit != 0 {
+                        !bits
+                    } else {
+                        bits ^ sign_bit
+                    };
+
+                    unsafe { buffer.get_unchecked_mut(..$size) }.copy_from_slice(&encoded.to_be_bytes());
                 }
             }
         )+
@@ -306,20 +364,136 @@ mod tests {
         }
 
         #[test]
-        fn encodes_signed_big_endian() {
-            assert_encode!(-0x12i8, [0xee]);
-            assert_encode!(-0x0102i16, [0xfe, 0xfe]);
-            assert_encode!(-0x0102_0304i32, [0xfe, 0xfd, 0xfc, 0xfc]);
-            assert_encode!(-0x0102_0304_0506_0708i64, [
-                0xfe, 0xfd, 0xfc, 0xfb, 0xfa, 0xf9, 0xf8, 0xf8,
+        fn encodes_signed_order_preserving_golden_vectors() {
+            // Signed encoding flips the MSB of the big-endian representation.
+            // i8: -128 (0x80) -> 0x00, -1 (0xFF) -> 0x7F, 0 (0x00) -> 0x80, 127 (0x7F) -> 0xFF
+            assert_encode!(i8::MIN, [0x00]);
+            assert_encode!(-1i8, [0x7f]);
+            assert_encode!(0i8, [0x80]);
+            assert_encode!(1i8, [0x81]);
+            assert_encode!(i8::MAX, [0xff]);
+
+            // i16
+            assert_encode!(i16::MIN, [0x00, 0x00]);
+            assert_encode!(-1i16, [0x7f, 0xff]);
+            assert_encode!(0i16, [0x80, 0x00]);
+            assert_encode!(i16::MAX, [0xff, 0xff]);
+
+            // i32
+            assert_encode!(i32::MIN, [0x00, 0x00, 0x00, 0x00]);
+            assert_encode!(-1i32, [0x7f, 0xff, 0xff, 0xff]);
+            assert_encode!(0i32, [0x80, 0x00, 0x00, 0x00]);
+            assert_encode!(i32::MAX, [0xff, 0xff, 0xff, 0xff]);
+
+            // i64
+            assert_encode!(i64::MIN, [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
+            assert_encode!(-1i64, [0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]);
+            assert_encode!(0i64, [0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
+            assert_encode!(i64::MAX, [0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]);
+
+            // isize (64-bit)
+            assert_encode!(isize::MIN, [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
+            assert_encode!(-1isize, [0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]);
+            assert_encode!(0isize, [0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
+            assert_encode!(isize::MAX, [0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]);
+
+            // i128
+            assert_encode!(i128::MIN, [
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x00, 0x00,
             ]);
-            assert_encode!(-0x0102_0304_0506_0708isize, [
-                0xfe, 0xfd, 0xfc, 0xfb, 0xfa, 0xf9, 0xf8, 0xf8,
+            assert_encode!(-1i128, [
+                0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+                0xff, 0xff,
             ]);
-            assert_encode!(-0x0102_0304_0506_0708_090a_0b0c_0d0e_0f10i128, [
-                0xfe, 0xfd, 0xfc, 0xfb, 0xfa, 0xf9, 0xf8, 0xf7, 0xf6, 0xf5, 0xf4, 0xf3, 0xf2, 0xf1,
-                0xf0, 0xf0,
+            assert_encode!(0i128, [
+                0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x00, 0x00,
             ]);
+            assert_encode!(i128::MAX, [
+                0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+                0xff, 0xff,
+            ]);
+        }
+
+        fn encode<T: CanonicalEncode>(value: &T) -> Vec<u8> {
+            let mut buffer = vec![0u8; T::SIZE];
+            unsafe { value.encode_into(&mut buffer) };
+            buffer
+        }
+
+        #[test]
+        fn signed_i8_encoding_preserves_numeric_order() {
+            let values: Vec<i8> = vec![i8::MIN, -100, -2, -1, 0, 1, 2, 100, i8::MAX];
+            let encoded: Vec<Vec<u8>> = values.iter().map(encode).collect();
+            for window in encoded.windows(2) {
+                assert!(window[0] < window[1], "order violated");
+            }
+        }
+
+        #[test]
+        fn signed_i16_encoding_preserves_numeric_order() {
+            let values: Vec<i16> = vec![i16::MIN, -1000, -2, -1, 0, 1, 2, 1000, i16::MAX];
+            let encoded: Vec<Vec<u8>> = values.iter().map(encode).collect();
+            for window in encoded.windows(2) {
+                assert!(window[0] < window[1], "order violated");
+            }
+        }
+
+        #[test]
+        fn signed_i32_encoding_preserves_numeric_order() {
+            let values: Vec<i32> = vec![i32::MIN, -100_000, -2, -1, 0, 1, 2, 100_000, i32::MAX];
+            let encoded: Vec<Vec<u8>> = values.iter().map(encode).collect();
+            for window in encoded.windows(2) {
+                assert!(window[0] < window[1], "order violated");
+            }
+        }
+
+        #[test]
+        fn signed_i64_encoding_preserves_numeric_order() {
+            let values: Vec<i64> = vec![
+                i64::MIN,
+                -1_000_000_000,
+                -2,
+                -1,
+                0,
+                1,
+                2,
+                1_000_000_000,
+                i64::MAX,
+            ];
+            let encoded: Vec<Vec<u8>> = values.iter().map(encode).collect();
+            for window in encoded.windows(2) {
+                assert!(window[0] < window[1], "order violated");
+            }
+        }
+
+        #[test]
+        fn signed_i128_encoding_preserves_numeric_order() {
+            let values: Vec<i128> = vec![
+                i128::MIN,
+                -1_000_000_000_000_000_000,
+                -2,
+                -1,
+                0,
+                1,
+                2,
+                1_000_000_000_000_000_000,
+                i128::MAX,
+            ];
+            let encoded: Vec<Vec<u8>> = values.iter().map(encode).collect();
+            for window in encoded.windows(2) {
+                assert!(window[0] < window[1], "order violated");
+            }
+        }
+
+        #[test]
+        fn unsigned_encoding_preserves_numeric_order() {
+            let values: Vec<u64> = vec![0, 1, 2, 255, 256, u64::MAX - 1, u64::MAX];
+            let encoded: Vec<Vec<u8>> = values.iter().map(encode).collect();
+            for window in encoded.windows(2) {
+                assert!(window[0] < window[1], "order violated");
+            }
         }
     }
 
@@ -333,23 +507,123 @@ mod tests {
         }
 
         #[test]
-        fn encodes_f32_canonical_bytes() {
-            assert_encode!(f32::from_bits(0x7fc0_0001), [0x7f, 0xc0, 0x00, 0x00]);
-            assert_encode!(f32::NAN, [0x7f, 0xc0, 0x00, 0x00]);
-            assert_encode!(0.0f32, [0x00, 0x00, 0x00, 0x00]);
-            assert_encode!(-0.0f32, [0x00, 0x00, 0x00, 0x00]);
-            assert_encode!(1.5f32, [0x3f, 0xc0, 0x00, 0x00]);
+        fn encodes_f32_order_preserving_golden_vectors() {
+            // -inf: bits=0xFF800000, negative -> invert all -> 0x007FFFFF
+            assert_encode!(f32::NEG_INFINITY, [0x00, 0x7f, 0xff, 0xff]);
+            // -1.5: bits=0xBFC00000, negative -> invert all -> 0x403FFFFF
+            assert_encode!(-1.5f32, [0x40, 0x3f, 0xff, 0xff]);
+            // -0.0 normalized to +0.0: bits=0, non-negative -> flip sign -> 0x80000000
+            assert_encode!(-0.0f32, [0x80, 0x00, 0x00, 0x00]);
+            // +0.0: bits=0, non-negative -> flip sign -> 0x80000000
+            assert_encode!(0.0f32, [0x80, 0x00, 0x00, 0x00]);
+            // 1.5: bits=0x3FC00000, non-negative -> flip sign -> 0xBFC00000
+            assert_encode!(1.5f32, [0xbf, 0xc0, 0x00, 0x00]);
+            // +inf: bits=0x7F800000, non-negative -> flip sign -> 0xFF800000
+            assert_encode!(f32::INFINITY, [0xff, 0x80, 0x00, 0x00]);
+            // NaN: canonical bits=0x7FC00000, non-negative -> flip sign -> 0xFFC00000
+            assert_encode!(f32::NAN, [0xff, 0xc0, 0x00, 0x00]);
+            assert_encode!(f32::from_bits(0x7fc0_0001), [0xff, 0xc0, 0x00, 0x00]);
         }
 
         #[test]
-        fn encodes_f64_canonical_bytes() {
-            assert_encode!(f64::from_bits(0x7ff8_0000_0000_0001), [
-                0x7f, 0xf8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        fn encodes_f64_order_preserving_golden_vectors() {
+            // -inf: bits=0xFFF0000000000000, negative -> invert all -> 0x000FFFFFFFFFFFFF
+            assert_encode!(f64::NEG_INFINITY, [
+                0x00, 0x0f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
             ]);
-            assert_encode!(f64::NAN, [0x7f, 0xf8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,]);
-            assert_encode!(0.0f64, [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,]);
-            assert_encode!(-0.0f64, [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,]);
-            assert_encode!(1.5f64, [0x3f, 0xf8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,]);
+            // -1.5: bits=0xBFF8000000000000, negative -> invert all -> 0x4007FFFFFFFFFFFF
+            assert_encode!(-1.5f64, [0x40, 0x07, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]);
+            // -0.0 normalized to +0.0: bits=0, non-negative -> flip sign -> 0x8000000000000000
+            assert_encode!(-0.0f64, [0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
+            // +0.0: bits=0, non-negative -> flip sign -> 0x8000000000000000
+            assert_encode!(0.0f64, [0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
+            // 1.5: bits=0x3FF8000000000000, non-negative -> flip sign -> 0xBFF8000000000000
+            assert_encode!(1.5f64, [0xbf, 0xf8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
+            // +inf: bits=0x7FF0000000000000, non-negative -> flip sign -> 0xFFF0000000000000
+            assert_encode!(f64::INFINITY, [
+                0xff, 0xf0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+            ]);
+            // NaN: canonical bits=0x7FF8000000000000, non-negative -> flip sign ->
+            // 0xFFF8000000000000
+            assert_encode!(f64::NAN, [0xff, 0xf8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
+            assert_encode!(f64::from_bits(0x7ff8_0000_0000_0001), [
+                0xff, 0xf8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            ]);
+        }
+
+        fn encode<T: CanonicalEncode>(value: &T) -> Vec<u8> {
+            let mut buffer = vec![0u8; T::SIZE];
+            unsafe { value.encode_into(&mut buffer) };
+            buffer
+        }
+
+        #[test]
+        fn f32_encoding_preserves_canonical_order() {
+            let values: Vec<f32> = vec![
+                f32::NEG_INFINITY,
+                -1e30,
+                -1.5,
+                -f32::MIN_POSITIVE,
+                0.0,
+                f32::MIN_POSITIVE,
+                1.5,
+                1e30,
+                f32::INFINITY,
+                f32::NAN,
+            ];
+            let encoded: Vec<Vec<u8>> = values.iter().map(encode).collect();
+            for (i, window) in encoded.windows(2).enumerate() {
+                assert!(
+                    window[0] < window[1],
+                    "f32 order violated at index {i}: {:?} !< {:?}",
+                    values[i],
+                    values[i + 1]
+                );
+            }
+        }
+
+        #[test]
+        fn f64_encoding_preserves_canonical_order() {
+            let values: Vec<f64> = vec![
+                f64::NEG_INFINITY,
+                -1e300,
+                -1.5,
+                -f64::MIN_POSITIVE,
+                0.0,
+                f64::MIN_POSITIVE,
+                1.5,
+                1e300,
+                f64::INFINITY,
+                f64::NAN,
+            ];
+            let encoded: Vec<Vec<u8>> = values.iter().map(encode).collect();
+            for (i, window) in encoded.windows(2).enumerate() {
+                assert!(
+                    window[0] < window[1],
+                    "f64 order violated at index {i}: {:?} !< {:?}",
+                    values[i],
+                    values[i + 1]
+                );
+            }
+        }
+
+        #[test]
+        fn negative_zero_and_positive_zero_encode_identically() {
+            assert_eq!(encode(&-0.0f32), encode(&0.0f32));
+            assert_eq!(encode(&-0.0f64), encode(&0.0f64));
+        }
+
+        #[test]
+        fn all_nan_payloads_encode_identically() {
+            let nan_a = f32::from_bits(0x7fc0_0001);
+            let nan_b = f32::from_bits(0x7fc0_dead);
+            assert_eq!(encode(&nan_a), encode(&nan_b));
+            assert_eq!(encode(&nan_a), encode(&f32::NAN));
+
+            let nan_c = f64::from_bits(0x7ff8_0000_0000_0001);
+            let nan_d = f64::from_bits(0x7ff8_dead_beef_0000);
+            assert_eq!(encode(&nan_c), encode(&nan_d));
+            assert_eq!(encode(&nan_c), encode(&f64::NAN));
         }
     }
 
@@ -370,6 +644,57 @@ mod tests {
                 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a,
             ]);
         }
+
+        fn encode<T: CanonicalEncode>(value: &T) -> Vec<u8> {
+            let mut buffer = vec![0u8; T::SIZE];
+            unsafe { value.encode_into(&mut buffer) };
+            buffer
+        }
+
+        #[test]
+        fn tuple_inherits_lexicographic_order_from_signed_components() {
+            let values: Vec<(i32, i32)> = vec![
+                (i32::MIN, 0),
+                (-1, 0),
+                (-1, i32::MAX),
+                (0, i32::MIN),
+                (0, 0),
+                (0, 1),
+                (1, i32::MIN),
+                (i32::MAX, i32::MAX),
+            ];
+            let encoded: Vec<Vec<u8>> = values.iter().map(encode).collect();
+            for (i, window) in encoded.windows(2).enumerate() {
+                assert!(
+                    window[0] < window[1],
+                    "tuple order violated at index {i}: {:?} !< {:?}",
+                    values[i],
+                    values[i + 1]
+                );
+            }
+        }
+
+        #[test]
+        fn tuple_inherits_lexicographic_order_from_float_components() {
+            let values: Vec<(f64, u32)> = vec![
+                (f64::NEG_INFINITY, 0),
+                (-1.0, 0),
+                (-1.0, u32::MAX),
+                (0.0, 0),
+                (0.0, 1),
+                (1.0, 0),
+                (f64::INFINITY, 0),
+            ];
+            let encoded: Vec<Vec<u8>> = values.iter().map(encode).collect();
+            for (i, window) in encoded.windows(2).enumerate() {
+                assert!(
+                    window[0] < window[1],
+                    "tuple order violated at index {i}: {:?} !< {:?}",
+                    values[i],
+                    values[i + 1]
+                );
+            }
+        }
     }
 
     mod array_encode {
@@ -385,6 +710,35 @@ mod tests {
         #[test]
         fn zero_sized_array_is_empty() {
             assert_encode!([(); 8], []);
+        }
+
+        fn encode<T: CanonicalEncode>(value: &T) -> Vec<u8> {
+            let mut buffer = vec![0u8; T::SIZE];
+            unsafe { value.encode_into(&mut buffer) };
+            buffer
+        }
+
+        #[test]
+        fn array_inherits_lexicographic_order_from_signed_elements() {
+            let values: Vec<[i16; 3]> = vec![
+                [i16::MIN, 0, 0],
+                [-1, 0, 0],
+                [-1, i16::MAX, i16::MAX],
+                [0, i16::MIN, 0],
+                [0, 0, 0],
+                [0, 0, 1],
+                [1, i16::MIN, i16::MIN],
+                [i16::MAX, i16::MAX, i16::MAX],
+            ];
+            let encoded: Vec<Vec<u8>> = values.iter().map(encode).collect();
+            for (i, window) in encoded.windows(2).enumerate() {
+                assert!(
+                    window[0] < window[1],
+                    "array order violated at index {i}: {:?} !< {:?}",
+                    values[i],
+                    values[i + 1]
+                );
+            }
         }
     }
 
@@ -419,8 +773,8 @@ mod tests {
                 },
                 [
                     0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, // generation
-                    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-                    0x00, // selection: -0.0 canonicalized to +0.0
+                    0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                    0x00, // selection: -0.0 canonicalized to +0.0, sign bit flipped
                     0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, // counts
                 ]
             );

--- a/crates/ssa-workflow/src/cache/canonical_encode.rs
+++ b/crates/ssa-workflow/src/cache/canonical_encode.rs
@@ -1,9 +1,7 @@
 /// Canonical key format version embedded in every persistent namespace.
 ///
 /// Bumping this constant isolates all new cache entries from namespaces written under an older
-/// key encoding. The current version (`keyfmt-v2`) corresponds to the order-preserving numeric
-/// encoding introduced for signed integers and floating-point values. The legacy raw big-endian
-/// encoding is implicitly `keyfmt-v1` and is no longer produced.
+/// key encoding.
 pub(crate) const CANONICAL_KEY_FORMAT: &str = "keyfmt-v2";
 
 /// Encode a key into canonical bytes.
@@ -30,14 +28,8 @@ pub(crate) const CANONICAL_KEY_FORMAT: &str = "keyfmt-v2";
 /// - Tuples and arrays: concatenation of element encodings; lexicographic ordering is inherited
 ///   whenever every component encoding is order-preserving.
 ///
-/// User-defined `CanonicalEncode` implementations are not required to define a natural order.
-///
-/// # Breaking change (key format v2)
-///
-/// The order-preserving encoding for signed integers and floats is incompatible with the legacy
-/// raw big-endian encoding. Canonical bytes also feed RNG derivation, so signed-integer and
-/// floating-point inputs produce new stochastic streams. Persistent namespaces include a
-/// canonical-key-format version that isolates new entries from old ones.
+/// User-defined `CanonicalEncode` implementations are not required to be order-preserving, but
+/// should prefer it when the type has a natural order.
 pub trait CanonicalEncode {
     const SIZE: usize;
 
@@ -191,6 +183,8 @@ impl_encode_for_signed!(i8 => 1, i16 => 2, i32 => 4, i64 => 8, isize => 8, i128 
 macro_rules! impl_encode_for_float {
     ($($t:ident => $size:literal => $canonical_nan_bits:expr),+ $(,)?) => {
         $(
+            // Grouped by IEEE 754 fields (sign, exponent, quiet bit, payload), not nibbles.
+            #[allow(clippy::unusual_byte_groupings)]
             impl CanonicalEncode for $t {
                 const SIZE: usize = $size;
 

--- a/crates/ssa-workflow/src/cache/canonical_encode.rs
+++ b/crates/ssa-workflow/src/cache/canonical_encode.rs
@@ -227,11 +227,10 @@ macro_rules! impl_encode_for_float {
     };
 }
 
-// Canonical NaN bit patterns: positive quiet NaN (sign=0, exponent=all-ones, quiet bit=1,
-// payload=0).
+// Positive quiet NaN with zero payload (IEEE 754 field layout: sign_exponent_quiet_payload).
 impl_encode_for_float!(
-    f32 => 4 => 0x7fc0_0000u32,
-    f64 => 8 => 0x7ff8_0000_0000_0000u64,
+    f32 => 4 => 0b0_11111111_1_0000000000000000000000u32,
+    f64 => 8 => 0b0_11111111111_1_000000000000000000000000000000000000000000000000000u64,
 );
 
 macro_rules! impl_encode_for_tuple {

--- a/crates/ssa-workflow/src/cache/canonical_encode.rs
+++ b/crates/ssa-workflow/src/cache/canonical_encode.rs
@@ -286,6 +286,26 @@ mod tests {
         T::SIZE
     }
 
+    fn encode<T: CanonicalEncode>(value: &T) -> Vec<u8> {
+        let mut buffer = vec![0u8; T::SIZE];
+        unsafe { value.encode_into(&mut buffer) };
+        buffer
+    }
+
+    /// Assert that encoding `values` in order produces strictly increasing byte sequences.
+    #[track_caller]
+    fn assert_order_preserving<T: CanonicalEncode + std::fmt::Debug>(values: &[T]) {
+        let encoded: Vec<Vec<u8>> = values.iter().map(encode).collect();
+        for (i, window) in encoded.windows(2).enumerate() {
+            assert!(
+                window[0] < window[1],
+                "order violated at index {i}: {:?} !< {:?}",
+                values[i],
+                values[i + 1]
+            );
+        }
+    }
+
     macro_rules! assert_size {
         ($t:ty, $size:literal) => {
             assert_eq!(<$t as CanonicalEncode>::SIZE, $size);
@@ -417,15 +437,9 @@ mod tests {
             ]);
         }
 
-        fn encode<T: CanonicalEncode>(value: &T) -> Vec<u8> {
-            let mut buffer = vec![0u8; T::SIZE];
-            unsafe { value.encode_into(&mut buffer) };
-            buffer
-        }
-
         #[test]
         fn signed_i8_encoding_preserves_numeric_order() {
-            let values: Vec<i8> = vec![
+            assert_order_preserving(&[
                 i8::MIN,
                 i8::MIN + 1,
                 -100,
@@ -437,16 +451,12 @@ mod tests {
                 100,
                 i8::MAX - 1,
                 i8::MAX,
-            ];
-            let encoded: Vec<Vec<u8>> = values.iter().map(encode).collect();
-            for window in encoded.windows(2) {
-                assert!(window[0] < window[1], "order violated");
-            }
+            ]);
         }
 
         #[test]
         fn signed_i16_encoding_preserves_numeric_order() {
-            let values: Vec<i16> = vec![
+            assert_order_preserving(&[
                 i16::MIN,
                 i16::MIN + 1,
                 -1000,
@@ -458,16 +468,12 @@ mod tests {
                 1000,
                 i16::MAX - 1,
                 i16::MAX,
-            ];
-            let encoded: Vec<Vec<u8>> = values.iter().map(encode).collect();
-            for window in encoded.windows(2) {
-                assert!(window[0] < window[1], "order violated");
-            }
+            ]);
         }
 
         #[test]
         fn signed_i32_encoding_preserves_numeric_order() {
-            let values: Vec<i32> = vec![
+            assert_order_preserving(&[
                 i32::MIN,
                 i32::MIN + 1,
                 -100_000,
@@ -479,16 +485,12 @@ mod tests {
                 100_000,
                 i32::MAX - 1,
                 i32::MAX,
-            ];
-            let encoded: Vec<Vec<u8>> = values.iter().map(encode).collect();
-            for window in encoded.windows(2) {
-                assert!(window[0] < window[1], "order violated");
-            }
+            ]);
         }
 
         #[test]
         fn signed_i64_encoding_preserves_numeric_order() {
-            let values: Vec<i64> = vec![
+            assert_order_preserving(&[
                 i64::MIN,
                 i64::MIN + 1,
                 -1_000_000_000,
@@ -500,16 +502,12 @@ mod tests {
                 1_000_000_000,
                 i64::MAX - 1,
                 i64::MAX,
-            ];
-            let encoded: Vec<Vec<u8>> = values.iter().map(encode).collect();
-            for window in encoded.windows(2) {
-                assert!(window[0] < window[1], "order violated");
-            }
+            ]);
         }
 
         #[test]
         fn signed_i128_encoding_preserves_numeric_order() {
-            let values: Vec<i128> = vec![
+            assert_order_preserving(&[
                 i128::MIN,
                 i128::MIN + 1,
                 -1_000_000_000_000_000_000,
@@ -521,20 +519,12 @@ mod tests {
                 1_000_000_000_000_000_000,
                 i128::MAX - 1,
                 i128::MAX,
-            ];
-            let encoded: Vec<Vec<u8>> = values.iter().map(encode).collect();
-            for window in encoded.windows(2) {
-                assert!(window[0] < window[1], "order violated");
-            }
+            ]);
         }
 
         #[test]
         fn unsigned_encoding_preserves_numeric_order() {
-            let values: Vec<u64> = vec![0, 1, 2, 255, 256, u64::MAX - 1, u64::MAX];
-            let encoded: Vec<Vec<u8>> = values.iter().map(encode).collect();
-            for window in encoded.windows(2) {
-                assert!(window[0] < window[1], "order violated");
-            }
+            assert_order_preserving(&[0u64, 1, 2, 255, 256, u64::MAX - 1, u64::MAX]);
         }
     }
 
@@ -592,16 +582,10 @@ mod tests {
             ]);
         }
 
-        fn encode<T: CanonicalEncode>(value: &T) -> Vec<u8> {
-            let mut buffer = vec![0u8; T::SIZE];
-            unsafe { value.encode_into(&mut buffer) };
-            buffer
-        }
-
         #[test]
         fn f32_encoding_preserves_canonical_order() {
             let smallest_subnormal = f32::from_bits(1);
-            let values: Vec<f32> = vec![
+            assert_order_preserving(&[
                 f32::NEG_INFINITY,
                 -1e30,
                 -1.5,
@@ -614,22 +598,13 @@ mod tests {
                 1e30,
                 f32::INFINITY,
                 f32::NAN,
-            ];
-            let encoded: Vec<Vec<u8>> = values.iter().map(encode).collect();
-            for (i, window) in encoded.windows(2).enumerate() {
-                assert!(
-                    window[0] < window[1],
-                    "f32 order violated at index {i}: {:?} !< {:?}",
-                    values[i],
-                    values[i + 1]
-                );
-            }
+            ]);
         }
 
         #[test]
         fn f64_encoding_preserves_canonical_order() {
             let smallest_subnormal = f64::from_bits(1);
-            let values: Vec<f64> = vec![
+            assert_order_preserving(&[
                 f64::NEG_INFINITY,
                 -1e300,
                 -1.5,
@@ -642,16 +617,7 @@ mod tests {
                 1e300,
                 f64::INFINITY,
                 f64::NAN,
-            ];
-            let encoded: Vec<Vec<u8>> = values.iter().map(encode).collect();
-            for (i, window) in encoded.windows(2).enumerate() {
-                assert!(
-                    window[0] < window[1],
-                    "f64 order violated at index {i}: {:?} !< {:?}",
-                    values[i],
-                    values[i + 1]
-                );
-            }
+            ]);
         }
 
         #[test]
@@ -707,15 +673,9 @@ mod tests {
             ]);
         }
 
-        fn encode<T: CanonicalEncode>(value: &T) -> Vec<u8> {
-            let mut buffer = vec![0u8; T::SIZE];
-            unsafe { value.encode_into(&mut buffer) };
-            buffer
-        }
-
         #[test]
         fn tuple_inherits_lexicographic_order_from_signed_components() {
-            let values: Vec<(i32, i32)> = vec![
+            assert_order_preserving(&[
                 (i32::MIN, 0),
                 (-1, 0),
                 (-1, i32::MAX),
@@ -724,38 +684,20 @@ mod tests {
                 (0, 1),
                 (1, i32::MIN),
                 (i32::MAX, i32::MAX),
-            ];
-            let encoded: Vec<Vec<u8>> = values.iter().map(encode).collect();
-            for (i, window) in encoded.windows(2).enumerate() {
-                assert!(
-                    window[0] < window[1],
-                    "tuple order violated at index {i}: {:?} !< {:?}",
-                    values[i],
-                    values[i + 1]
-                );
-            }
+            ]);
         }
 
         #[test]
         fn tuple_inherits_lexicographic_order_from_float_components() {
-            let values: Vec<(f64, u32)> = vec![
-                (f64::NEG_INFINITY, 0),
+            assert_order_preserving(&[
+                (f64::NEG_INFINITY, 0u32),
                 (-1.0, 0),
                 (-1.0, u32::MAX),
                 (0.0, 0),
                 (0.0, 1),
                 (1.0, 0),
                 (f64::INFINITY, 0),
-            ];
-            let encoded: Vec<Vec<u8>> = values.iter().map(encode).collect();
-            for (i, window) in encoded.windows(2).enumerate() {
-                assert!(
-                    window[0] < window[1],
-                    "tuple order violated at index {i}: {:?} !< {:?}",
-                    values[i],
-                    values[i + 1]
-                );
-            }
+            ]);
         }
     }
 
@@ -774,15 +716,9 @@ mod tests {
             assert_encode!([(); 8], []);
         }
 
-        fn encode<T: CanonicalEncode>(value: &T) -> Vec<u8> {
-            let mut buffer = vec![0u8; T::SIZE];
-            unsafe { value.encode_into(&mut buffer) };
-            buffer
-        }
-
         #[test]
         fn array_inherits_lexicographic_order_from_signed_elements() {
-            let values: Vec<[i16; 3]> = vec![
+            assert_order_preserving(&[
                 [i16::MIN, 0, 0],
                 [-1, 0, 0],
                 [-1, i16::MAX, i16::MAX],
@@ -791,16 +727,7 @@ mod tests {
                 [0, 0, 1],
                 [1, i16::MIN, i16::MIN],
                 [i16::MAX, i16::MAX, i16::MAX],
-            ];
-            let encoded: Vec<Vec<u8>> = values.iter().map(encode).collect();
-            for (i, window) in encoded.windows(2).enumerate() {
-                assert!(
-                    window[0] < window[1],
-                    "array order violated at index {i}: {:?} !< {:?}",
-                    values[i],
-                    values[i + 1]
-                );
-            }
+            ]);
         }
     }
 

--- a/crates/ssa-workflow/src/cache/storage/namespace.rs
+++ b/crates/ssa-workflow/src/cache/storage/namespace.rs
@@ -1,6 +1,10 @@
-use crate::{cache::codec::ValueFormat, identity::ComputationPath};
+use crate::{
+    cache::{canonical_encode::CANONICAL_KEY_FORMAT, codec::ValueFormat},
+    identity::ComputationPath,
+};
 
-/// Physical storage namespace derived from a computation path and value format.
+/// Physical storage namespace derived from a computation path, canonical key format, and value
+/// format.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct StorageNamespace {
     name: String,
@@ -8,8 +12,11 @@ pub struct StorageNamespace {
 
 impl StorageNamespace {
     /// Create a storage namespace from a computation path and value format.
+    ///
+    /// The namespace includes the canonical key format version so that persistent caches written
+    /// under an older key encoding are never read through the new namespace.
     pub fn new(path: &ComputationPath, value_format: ValueFormat) -> Self {
-        let name = format!("{path}__{value_format}");
+        let name = format!("{path}__{CANONICAL_KEY_FORMAT}__{value_format}");
 
         Self { name }
     }
@@ -30,11 +37,14 @@ mod tests {
     const FORMAT: ValueFormat = ValueFormat::new("bitcode06-v1");
 
     #[test]
-    fn storage_namespace_is_readable_and_includes_value_format() {
+    fn storage_namespace_includes_key_format_and_value_format() {
         let path = ComputationPath::root_from_str(COMPUTATION_A);
         let namespace = StorageNamespace::new(&path, FORMAT);
 
-        assert_eq!(namespace.as_str(), "computation-a-v1__bitcode06-v1");
+        assert_eq!(
+            namespace.as_str(),
+            "computation-a-v1__keyfmt-v2__bitcode06-v1"
+        );
     }
 
     #[test]
@@ -42,7 +52,10 @@ mod tests {
         let path = ComputationPath::root_from_str("trajectory-v1").child_from_str("summary-v1");
         let namespace = StorageNamespace::new(&path, FORMAT);
 
-        assert_eq!(namespace.as_str(), "summary-v1_trajectory-v1__bitcode06-v1");
+        assert_eq!(
+            namespace.as_str(),
+            "summary-v1_trajectory-v1__keyfmt-v2__bitcode06-v1"
+        );
     }
 
     #[test]

--- a/crates/ssa-workflow/src/compute/stochastic/input/mod.rs
+++ b/crates/ssa-workflow/src/compute/stochastic/input/mod.rs
@@ -109,4 +109,54 @@ mod tests {
         assert_eq!(encoded_new, encoded_tuple);
         assert_eq!(encoded_new, encoded_fields);
     }
+
+    fn encode<T: CanonicalEncode>(value: &T) -> Vec<u8> {
+        let mut buffer = vec![0u8; T::SIZE];
+        unsafe { value.encode_into(&mut buffer) };
+        buffer
+    }
+
+    #[test]
+    fn stochastic_input_inherits_order_from_signed_param_and_repetition() {
+        // Parameter-major order: all repetitions for param[0], then param[1], etc.
+        let inputs: Vec<StochasticInput<i32>> = vec![
+            StochasticInput::new(i32::MIN, 0),
+            StochasticInput::new(i32::MIN, 1),
+            StochasticInput::new(-1, 0),
+            StochasticInput::new(-1, u64::MAX),
+            StochasticInput::new(0, 0),
+            StochasticInput::new(0, 1),
+            StochasticInput::new(1, 0),
+            StochasticInput::new(i32::MAX, u64::MAX),
+        ];
+        let encoded: Vec<Vec<u8>> = inputs.iter().map(encode).collect();
+        for (i, window) in encoded.windows(2).enumerate() {
+            assert!(
+                window[0] < window[1],
+                "StochasticInput order violated at index {i}: {:?} !< {:?}",
+                inputs[i],
+                inputs[i + 1]
+            );
+        }
+    }
+
+    #[test]
+    fn stochastic_input_inherits_order_from_float_param() {
+        let inputs: Vec<StochasticInput<f64>> = vec![
+            StochasticInput::new(f64::NEG_INFINITY, 0),
+            StochasticInput::new(-1.5, 0),
+            StochasticInput::new(-1.5, 1),
+            StochasticInput::new(0.0, 0),
+            StochasticInput::new(1.5, 0),
+            StochasticInput::new(f64::INFINITY, 0),
+            StochasticInput::new(f64::NAN, 0),
+        ];
+        let encoded: Vec<Vec<u8>> = inputs.iter().map(encode).collect();
+        for (i, window) in encoded.windows(2).enumerate() {
+            assert!(
+                window[0] < window[1],
+                "StochasticInput<f64> order violated at index {i}"
+            );
+        }
+    }
 }

--- a/crates/ssa-workflow/src/compute/transform/tests.rs
+++ b/crates/ssa-workflow/src/compute/transform/tests.rs
@@ -131,6 +131,56 @@ fn dependent_stochastic_input_encodes_param_source_then_repetition() {
     assert_eq!(encoded, &[0x01, 0x02, 0x03, 0x04, 0, 0, 0, 0, 0, 0, 0, 5]);
 }
 
+fn encode_canonical<T: crate::cache::CanonicalEncode>(value: &T) -> Vec<u8> {
+    let mut buffer = vec![0u8; T::SIZE];
+    unsafe { value.encode_into(&mut buffer) };
+    buffer
+}
+
+#[test]
+fn dependent_input_inherits_lexicographic_order() {
+    let inputs: Vec<DependentInput<i32, i32>> = vec![
+        DependentInput::new(i32::MIN, 0),
+        DependentInput::new(-1, i32::MAX),
+        DependentInput::new(0, i32::MIN),
+        DependentInput::new(0, 0),
+        DependentInput::new(0, 1),
+        DependentInput::new(1, i32::MIN),
+        DependentInput::new(i32::MAX, i32::MAX),
+    ];
+    let encoded: Vec<Vec<u8>> = inputs.iter().map(encode_canonical).collect();
+    for (i, window) in encoded.windows(2).enumerate() {
+        assert!(
+            window[0] < window[1],
+            "DependentInput order violated at index {i}: {:?} !< {:?}",
+            inputs[i],
+            inputs[i + 1]
+        );
+    }
+}
+
+#[test]
+fn dependent_stochastic_input_inherits_lexicographic_order() {
+    let inputs: Vec<DependentStochasticInput<i16, f64>> = vec![
+        DependentStochasticInput::new(i16::MIN, f64::NEG_INFINITY, 0),
+        DependentStochasticInput::new(-1, -1.0, u64::MAX),
+        DependentStochasticInput::new(0, 0.0, 0),
+        DependentStochasticInput::new(0, 0.0, 1),
+        DependentStochasticInput::new(0, 1.0, 0),
+        DependentStochasticInput::new(1, f64::INFINITY, 0),
+        DependentStochasticInput::new(i16::MAX, f64::NAN, u64::MAX),
+    ];
+    let encoded: Vec<Vec<u8>> = inputs.iter().map(encode_canonical).collect();
+    for (i, window) in encoded.windows(2).enumerate() {
+        assert!(
+            window[0] < window[1],
+            "DependentStochasticInput order violated at index {i}: {:?} !< {:?}",
+            inputs[i],
+            inputs[i + 1]
+        );
+    }
+}
+
 #[test]
 fn parameterized_transform_recomputes_only_transform_for_param_changes() -> Result<()> {
     let source_calls = Arc::new(AtomicUsize::new(0));


### PR DESCRIPTION
## Summary

Make built-in numeric `CanonicalEncode` implementations lexicographically order-preserving, so that ordered storage backends can preserve numeric sweep locality when walking keys.

This is a breaking canonical-key change: signed-integer and floating-point inputs produce new cache keys and new stochastic RNG streams. A `keyfmt-v2` segment is added to `StorageNamespace` to isolate new entries from legacy namespaces.

Closes #81

## Changes

- **Signed integers**: encode big-endian two's-complement bytes with the MSB flipped, so `MIN` encodes lowest and `MAX` encodes highest.
- **Floats**: after normalizing all NaN payloads to an explicit positive quiet NaN (sign=0, exponent=all-ones, quiet bit=1, payload=0) and collapsing `-0.0` to `+0.0`, apply the standard sign-magnitude transform — invert all bits for negatives, flip only the sign bit for non-negatives. Canonical order: `-inf < finite negatives < 0 < finite positives < +inf < NaN`.
- **Namespace isolation**: `StorageNamespace` now includes `keyfmt-v2` between the computation path and value format, preventing old-format entries from being read through the new namespace.
- **`CANONICAL_KEY_FORMAT`** constant lives in `canonical_encode.rs` alongside the encoding it versions.
- **Documentation**: trait-level docs describe the order-preserving guarantee and breaking-change notice; README gains a "Canonical Key Encoding" section.
- **Tests**: golden vectors for all signed widths (i8–i128, isize) and both float widths, order property tests covering subnormals and boundary values, `StochasticInput`/`DependentInput`/`DependentStochasticInput` inherited-order tests, signaling/negative NaN normalization coverage.

## Validation

- `cargo check` (workspace)
- `cargo test` (190 passed)
- `cargo clippy --all-targets -- -D warnings`
- `cargo +nightly fmt -- --check`